### PR TITLE
Add Helm Release Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --config ct.yaml --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
@@ -46,17 +47,21 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
       
       - name: Secret setup 
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           kubectl create namespace opentelemetry
           kubectl create secret generic otel-collector-secret -n opentelemetry --from-literal=LS_TOKEN=TEST_TOKEN
 
       - name: Dependencies 
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.8.0 --set installCRDs=true --wait
           helm install opentelemetry-operator open-telemetry/opentelemetry-operator -n opentelemetry-operator --create-namespace --wait
       
       - name: Run chart-testing collector-k8s (install)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct install --config ct.yaml --charts ./charts/collector-k8s --namespace opentelemetry --debug
 
       - name: Run chart-testing kube-otel-state (install)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct install --config ct.yaml --charts ./charts/kube-otel-stack --namespace opentelemetry --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           version: v3.10.0
 
+      - name: Add Helm Repos
+        run: |
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo add prometheus https://prometheus-community.github.io/helm-charts
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1
         env:


### PR DESCRIPTION
Adds a (manual) Github action for publishing the helm charts to a repository hosted on GitHub pages. The charts will be published according to their version(s) in `Chart.yaml`

Example: https://smithclay.github.io/prometheus-k8s-opentelemetry-collector/
Published index.yaml: https://smithclay.github.io/prometheus-k8s-opentelemetry-collector/index.yaml

**Pre-requisites before action can be run**

* `gh-pages` branch must exist on this repo