### PR TITLE
Add chart for HTTP checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,3 +65,7 @@ jobs:
       - name: Run chart-testing kube-otel-state (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --config ct.yaml --charts ./charts/kube-otel-stack --namespace opentelemetry --debug
+
+      - name: Run chart-testing http-check (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --config ct.yaml --charts ./charts/http-check --namespace opentelemetry --debug

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ This is the repository for Lightstep's recommended [Helm](https://helm.sh/) char
 
 ## Charts
 
-* [collector-k8s](https://github.com/lightstep/prometheus-k8s-opentelemetry-collector/tree/main/charts/collector-k8s) - Chart for using the OpenTelemetry Collector to scape static or dynamic metric targets.
-* [kube-otel-stack](https://github.com/lightstep/prometheus-k8s-opentelemetry-collector/tree/main/charts/kube-otel-stack) - Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
+* [collector-k8s](https://github.com/lightstep/lightstep/otel-collector-charts/tree/main/charts/collector-k8s) - Chart for using the OpenTelemetry Collector to scape static or dynamic metric targets.
+* [kube-otel-stack](https://github.com/lightstep/otel-collector-charts/tree/main/charts/kube-otel-stack) - Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
+* [http-check](https://github.com/lightstep/otel-collector-charts/tree/main/charts/kube-otel-stack) - Chart for running synthetic checks against HTTP endpoints.

--- a/charts/http-check/Chart.yaml
+++ b/charts/http-check/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: http-check
+description: Chart for performing synthetic HTTP checks using the OpenTelemetry Collector.
+type: application
+version: 0.0.1
+appVersion: 0.61.0
+dependencies:

--- a/charts/http-check/templates/collector.yaml
+++ b/charts/http-check/templates/collector.yaml
@@ -1,0 +1,109 @@
+{{ if .Values.collector.enabled }}
+{{ $collectorName := (print $.Release.Name "-" .Values.collector.name) }}
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: "{{ $collectorName }}"
+spec:
+  mode: {{ .Values.collector.mode }}
+  image: {{ .Values.collector.image }}
+  replicas: 1
+  ports:
+    - name: "metrics"
+      protocol: TCP
+      port: 8888
+  env:
+    - name: KUBE_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: KUBE_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: LS_TOKEN
+      valueFrom:
+        secretKeyRef:
+          key: LS_TOKEN
+          name: otel-collector-secret
+  config: |
+    receivers:
+      {{ range $name, $check := .Values.checks -}}
+      httpcheck/{{ $name }}:
+        endpoint: {{ $check.url }}
+        collection_interval: {{ $check.collection_interval | default "60s" | quote }}
+        method: {{ $check.method | default "GET" }}
+      {{ end }}
+
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 30
+      batch:
+        send_batch_size: 1000
+        timeout: 1s
+        send_batch_max_size: 1500
+
+    exporters:
+      otlp:
+        endpoint: ingest.lightstep.com:443
+        headers:
+          "lightstep-access-token": "${LS_TOKEN}"
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [{{ range $i, $name := keys .Values.checks -}} {{ print "httpcheck/" $name "," }} {{- end }}]
+          processors: [memory_limiter, batch]
+          exporters: [otlp]
+  resources:
+    {{- toYaml .Values.collector.resources | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ $collectorName }}"
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+  - servicemonitors
+  - podmonitors
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ $collectorName }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ $collectorName }}"
+subjects:
+- kind: ServiceAccount
+  # quirk of the Operator
+  name: "{{ $collectorName }}-collector"
+  namespace: {{ $.Release.Namespace }}
+---
+{{ end }}

--- a/charts/http-check/values.yaml
+++ b/charts/http-check/values.yaml
@@ -11,9 +11,9 @@ collector:
       memory: 500Mi
 
 checks:
- lightstep/api:
+  lightstep/api:
     url: https://api.lightstep.com
     method: GET
     collection_interval: 60s 
- cloudflare:
+  cloudflare:
     url: https://1.1.1.1

--- a/charts/http-check/values.yaml
+++ b/charts/http-check/values.yaml
@@ -1,0 +1,19 @@
+collector:
+  enabled: true
+  name: http-check
+  image: otel/opentelemetry-collector-contrib:0.63.0
+  resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 500m
+      memory: 500Mi
+
+checks:
+ lightstep/api:
+    url: https://api.lightstep.com
+    method: GET
+    collection_interval: 60s 
+ cloudflare:
+    url: https://1.1.1.1


### PR DESCRIPTION
* Adds helm chart for running the collector to make requests HTTP endpoints using the new `httpcheck` receiver.
* Configures the collector to send the result of checks specified in `values.yaml` to Lightstep.

cc @codeboten 