### PR TITLE
Update otel col operator SA's and healthcheck

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.0
-appVersion: 0.64.0
+version: 0.2.1
+appVersion: 0.70.0
 dependencies:
 # cert manager must be manually installed because it has CRDs
 # https://github.com/kubernetes-sigs/security-profiles-operator/issues/1062

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -19,7 +19,6 @@ spec:
   targetAllocator:
     enabled: true
     image: {{ $collector.targetallocator.image }}
-    serviceAccount: {{ $collectorName }}-targetallocator
     replicas: {{ $collector.targetallocator.replicas }}
     allocationStrategy: {{ $collector.targetallocator.allocationStrategy }}
     prometheusCR:
@@ -39,6 +38,8 @@ spec:
   config: |
     exporters:
       {{- toYaml $collector.config.exporters | nindent 6 }}
+    extensions:
+      {{- toYaml $collector.config.extensions | nindent 6 }}
     receivers:
       {{- toYaml $collector.config.receivers | nindent 6 }}
       prometheus:

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -45,16 +45,16 @@ collectors: []
 tracesCollector:
   enabled: false
   name: traces
-  image: otel/opentelemetry-collector-contrib:0.64.0
+  image: otel/opentelemetry-collector-contrib:0.71.0
   mode: deployment
   replicas: 1
   resources:
     limits:
-      cpu: 750m
-      memory: 1000Mi
+      cpu: 250m
+      memory: 250Mi
     requests:
-      cpu: 750m
-      memory: 1000Mi
+      cpu: 250m
+      memory: 250Mi
   env:
     - name: LS_TOKEN
       valueFrom:
@@ -98,7 +98,7 @@ tracesCollector:
 ## Default collector for metrics (includes infrastructure metrics)
 metricsCollector:
   name: metrics
-  image: otel/opentelemetry-collector-contrib:0.64.0
+  image: otel/opentelemetry-collector-contrib:0.71.0
   enabled: true
   mode: statefulset
   replicas: 3
@@ -106,18 +106,18 @@ metricsCollector:
     enabled: true
     allocationStrategy: "consistent-hashing"
     replicas: 2
-    image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.60.0
+    image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.70.0
     prometheusCR:
       enabled: true
   # No need for a scrape config when using prometheusCRs
   scrape_configs_file: "scrape_configs.yaml"
   resources:
     limits:
-      cpu: 750m
-      memory: 1000Mi
+      cpu: 250m
+      memory: 250Mi
     requests:
-      cpu: 750m
-      memory: 1000Mi
+      cpu: 250m
+      memory: 250Mi
   env:
     - name: LS_TOKEN
       valueFrom:
@@ -125,6 +125,14 @@ metricsCollector:
           key: LS_TOKEN
           name: otel-collector-secret
   config:
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+        path: "/"
+        check_collector_pipeline:
+          enabled: true
+          interval: "5m"
+          exporter_failure_threshold: 5
     receivers:
       otlp:
         protocols:
@@ -170,6 +178,8 @@ metricsCollector:
           "lightstep-access-token": "${LS_TOKEN}"
 
     service:
+      extensions:
+        - health_check
       pipelines:
         metrics:
           receivers: [prometheus]


### PR DESCRIPTION
# What Does This PR Do?

1. Adds support for [health_check](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/healthcheckextension/README.md) extension to enable liveness probes.
2. Removes references to a Service Account as creation is handled by the operator.
3. Bumps versions of `opentelemetry-collector-contrib` to `0.70.0`  and `target-allocator` to `0.71.0`
4. Right-sizes resource requests & limits for the `metricsCollector`