### PR TITLE
Add new api group requirement

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.70.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -110,6 +110,10 @@ rules:
   - servicemonitors
   - podmonitors
   verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
+  verbs: ["get", "list", "watch"]
 - apiGroups:
   - extensions
   resources:


### PR DESCRIPTION
In the latest version of the target allocator, there's a new required permission for service discovery