### PR TITLE
LS-44100:(helm): remove service.name relabeling from resource attributes

### DIFF
--- a/charts/collector-k8s/Chart.yaml
+++ b/charts/collector-k8s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: otelcollector
 description: Chart for using the OpenTelemetry Collector to scape static or dynamic metric targets.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.61.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/collector-k8s/values-daemonset.yaml
+++ b/charts/collector-k8s/values-daemonset.yaml
@@ -35,26 +35,6 @@ collectors:
           send_batch_size: 1000
           timeout: 1s
           send_batch_max_size: 1500
-        resource:
-          attributes:
-          - key: job
-            from_attribute: service.name
-            action: insert
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.daemonset.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.replicaset.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.statefulset.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.job.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.cronjob.name
 
       exporters:
         otlp:
@@ -66,7 +46,7 @@ collectors:
         pipelines:
           metrics:
             receivers: [prometheus]
-            processors: [memory_limiter, resourcedetection/gke, resource, batch]
+            processors: [memory_limiter, resourcedetection/gke, batch]
             exporters: [otlp]
 
   # The daemonset collector should be configured to scrape general app metrics that contains `prometheus.io/scrape: true` annotation.
@@ -106,26 +86,6 @@ collectors:
           send_batch_size: 1000
           timeout: 1s
           send_batch_max_size: 1500
-        resource:
-          attributes:
-          - key: job
-            from_attribute: service.name
-            action: insert
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.daemonset.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.replicaset.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.statefulset.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.job.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.cronjob.name
 
       exporters:
         otlp:
@@ -137,5 +97,5 @@ collectors:
         pipelines:
           metrics:
             receivers: [prometheus]
-            processors: [memory_limiter, resourcedetection/gke, resource, batch]
+            processors: [memory_limiter, resourcedetection/gke, batch]
             exporters: [otlp]

--- a/charts/collector-k8s/values-statefulset.yaml
+++ b/charts/collector-k8s/values-statefulset.yaml
@@ -43,24 +43,6 @@ collectors:
           send_batch_max_size: 1500
         resource:
           attributes:
-          - key: job
-            from_attribute: service.name
-            action: insert
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.daemonset.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.replicaset.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.statefulset.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.job.name
-          - key: service.name
-            action: upsert
-            from_attribute: k8s.cronjob.name
           - key: collector.name
             value: "${KUBE_POD_NAME}"
             action: insert

--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: 0.70.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -150,24 +150,6 @@ metricsCollector:
         send_batch_max_size: 1500
       resource:
         attributes:
-        - key: job
-          from_attribute: service.name
-          action: insert
-        - key: service.name
-          action: upsert
-          from_attribute: k8s.daemonset.name
-        - key: service.name
-          action: upsert
-          from_attribute: k8s.replicaset.name
-        - key: service.name
-          action: upsert
-          from_attribute: k8s.statefulset.name
-        - key: service.name
-          action: upsert
-          from_attribute: k8s.job.name
-        - key: service.name
-          action: upsert
-          from_attribute: k8s.cronjob.name
         - key: collector.name
           value: "${KUBE_POD_NAME}"
           action: insert


### PR DESCRIPTION
### What does this PR do?

Removes relabeling of `service.name` in the resource processor.

### Why are you making this change?

The resource processor relabels `service.name` from the value set by the otel sdk to the value of a workload specific label. e.g. when running collector as a statefulset, `service.name` is assigned the value from `k8s.statefulset.name`. This is confusing because `k8s.statefulset.name` is not a service, so this new labeling is misleading.

More context in original ticket: https://lightstep.atlassian.net/browse/LS-44100


### Testing

Ran the `kube-otel-stack` in different modes and confirmed `service.name` was no longer equal to the workload specific label (i.e relabeling wasn't happening because `k8s.replicaset.name` != `service.name`, `k8s.statefulset.name` != `service.name`).  Also confirmed that `service.name` refers to an actual service in my k8s cluster.