### PR TITLE
Set k8s.cluster.name for metrics

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: 0.70.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -44,6 +44,8 @@ spec:
 {{- end }}
   env:
     {{- toYaml $collector.env | nindent 4}}
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: "k8s.cluster.name={{ $collector.clusterName | default "unknown" }}"
     - name: KUBE_NODE_NAME
       valueFrom:
         fieldRef:

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -63,8 +63,6 @@ tracesCollector:
         secretKeyRef:
           key: LS_TOKEN
           name: otel-collector-secret
-    - name: OTEL_RESOURCE_ATTRIBUTES
-      value: ""
   config:
     receivers:
       otlp:

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -46,6 +46,7 @@ collectors: []
 tracesCollector:
   enabled: false
   name: traces
+  clusterName: ""
   image: otel/opentelemetry-collector-contrib:0.71.0
   mode: deployment
   replicas: 1
@@ -62,6 +63,8 @@ tracesCollector:
         secretKeyRef:
           key: LS_TOKEN
           name: otel-collector-secret
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: ""
   config:
     receivers:
       otlp:
@@ -73,6 +76,10 @@ tracesCollector:
         check_interval: 1s
         limit_percentage: 75
         spike_limit_percentage: 30
+      resourcedetection/env:
+        detectors: [env]
+        timeout: 2s
+        override: false
       batch:
         send_batch_size: 1000
         timeout: 1s
@@ -93,12 +100,13 @@ tracesCollector:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, resource, batch]
+          processors: [memory_limiter, resource, resourcedetection/env, batch]
           exporters: [otlp]
 
 ## Default collector for metrics (includes infrastructure metrics)
 metricsCollector:
   name: metrics
+  clusterName: ""
   image: otel/opentelemetry-collector-contrib:0.71.0
   enabled: true
   mode: statefulset
@@ -144,6 +152,10 @@ metricsCollector:
         check_interval: 1s
         limit_percentage: 75
         spike_limit_percentage: 30
+      resourcedetection/env:
+        detectors: [env]
+        timeout: 2s
+        override: false
       batch:
         send_batch_size: 1000
         timeout: 1s
@@ -166,7 +178,7 @@ metricsCollector:
       pipelines:
         metrics:
           receivers: [prometheus]
-          processors: [memory_limiter, resource, batch]
+          processors: [memory_limiter, resource, resourcedetection/env, batch]
           exporters: [otlp]
 
 ## Component scraping the kube api server


### PR DESCRIPTION
* Sets `k8s.cluster.name` (needs to be specified or looked up on install) for all metrics coming via the prometheus receiver.

To set, when installing run:

```
helm upgrade kube-otel-stack ./charts/kube-otel-stack -f ./charts/kube-otel-stack/values.yaml --set metricsCollector.clusterName=foo
```