### PR TITLE
Relabel service label to follow OTel semantic conventions

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: 0.73.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/scrape_configs.yaml
+++ b/charts/kube-otel-stack/scrape_configs.yaml
@@ -112,6 +112,14 @@
     source_labels:
     - id
     - pod
+  - action: replace
+    regex: "kube_service_info;(.*)"
+    replacement: "${1}"
+    separator: ";"
+    source_labels:
+    - __name__
+    - service
+    target_label: k8s_service_name
   metrics_path: "/metrics/cadvisor"
   relabel_configs:
   - action: replace

--- a/charts/kube-otel-stack/scrape_configs.yaml
+++ b/charts/kube-otel-stack/scrape_configs.yaml
@@ -112,14 +112,6 @@
     source_labels:
     - id
     - pod
-  - action: replace
-    regex: "kube_service_info;(.*)"
-    replacement: "${1}"
-    separator: ";"
-    source_labels:
-    - __name__
-    - service
-    target_label: k8s_service_name
   metrics_path: "/metrics/cadvisor"
   relabel_configs:
   - action: replace

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -179,6 +179,15 @@ metricsCollector:
         check_interval: 1s
         limit_percentage: 75
         spike_limit_percentage: 30
+      metricstransform/k8sservicename:
+        transforms:
+          - include: kube_service_info
+            match_type: strict
+            action: update
+            operations:
+              - action: update_label
+                label: service
+                new_label: k8s.service.name
       resourcedetection/env:
         detectors: [env]
         timeout: 2s
@@ -237,7 +246,7 @@ metricsCollector:
       pipelines:
         metrics:
           receivers: [prometheus, otlp]
-          processors: [memory_limiter, resource, resourcedetection/env, k8sattributes, batch]
+          processors: [memory_limiter, resource, resourcedetection/env, k8sattributes, metricstransform/k8sservicename, batch]
           exporters: [otlp]
 
 ## Component scraping the kube api server

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -90,7 +90,6 @@ tracesCollector:
                 name: k8s.pod.name
         extract:
           metadata:
-            - k8s.cluster.name
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.pod.uid
@@ -200,7 +199,6 @@ metricsCollector:
                 name: k8s.pod.name
         extract:
           metadata:
-            - k8s.cluster.name
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.pod.uid


### PR DESCRIPTION
* Relabel the `service` label on the `kube_service_info` metric to `k8s.service.name` to follow OTel semantic conventions.

We want the following metric, once ingested, to be able to be grouped by `k8s.service.name` instead of `service`: 
<img width="943" alt="image" src="https://github.com/lightstep/otel-collector-charts/assets/27153/a92e211d-ab6f-44d6-9b2f-5d24d5108916">

verified w/ `metricstransformprocessor`:
<img width="305" alt="image" src="https://github.com/lightstep/otel-collector-charts/assets/27153/5de7c93d-80d3-4626-a582-1c616740d126">
