### PR TITLE
Add a logging collector to kube-otel-stack

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: 0.73.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -108,6 +108,14 @@ spec:
       {{- toYaml $collector.config.service | nindent 6 }}
   resources:
     {{- toYaml $collector.resources | nindent 4 }}
+{{- if $collector.volumes }}
+  volumes:
+    {{- toYaml $collector.volumes | nindent 4 }}
+{{ end }}
+{{- if $collector.volumeMounts }}
+  volumeMounts:
+    {{- toYaml $collector.volumeMounts | nindent 4 }}
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -1,4 +1,4 @@
-{{ $collectorList := (append (append .Values.collectors .Values.tracesCollector) .Values.metricsCollector) }}
+{{ $collectorList := (append (append (append .Values.collectors .Values.tracesCollector) .Values.metricsCollector) .Values.logsCollector)}}
 {{ range $_, $collector := $collectorList -}}
 {{ if $collector.enabled }}
 {{ $collectorName := (print $.Release.Name "-" $collector.name) }}

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -262,7 +262,7 @@ logsCollector:
   name: logs
   clusterName: ""
   image: otel/opentelemetry-collector-contrib:0.80.0
-  enabled: true
+  enabled: false
   mode: daemonset
   resources:
     limits:

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -345,7 +345,8 @@ logsCollector:
             regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
             parse_from: attributes["log.file.path"]
             cache:
-              size: 128 # default maximum amount of Pods per Node is 110
+              # default maximum amount of Pods per Node is 110
+              size: 128
           # Rename attributes
           - type: move
             from: attributes.stream

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -266,7 +266,7 @@ logsCollector:
   name: logs
   clusterName: ""
   image: otel/opentelemetry-collector-contrib:0.76.3
-  enabled: true
+  enabled: false
   mode: daemonset
   resources:
     limits:

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -127,13 +127,11 @@ tracesCollector:
         traces:
           receivers: [otlp]
           processors:
-            [
-              memory_limiter,
-              resource,
-              resourcedetection/env,
-              k8sattributes,
-              batch,
-            ]
+            - memory_limiter
+            - resource
+            - resourcedetection/env
+            - k8sattributes
+            - batch
           exporters: [otlp]
 
 ## Default collector for metrics (includes infrastructure metrics)
@@ -252,14 +250,12 @@ metricsCollector:
         metrics:
           receivers: [prometheus, otlp]
           processors:
-            [
-              memory_limiter,
-              resource,
-              resourcedetection/env,
-              k8sattributes,
-              metricstransform/k8sservicename,
-              batch,
-            ]
+            - memory_limiter
+            - resource
+            - resourcedetection/env
+            - k8sattributes
+            - metricstransform/k8sservicename
+            - batch
           exporters: [otlp]
 
 logsCollector:
@@ -426,13 +422,11 @@ logsCollector:
         logs:
           receivers: [filelog]
           processors:
-            [
-              memory_limiter,
-              resource,
-              resourcedetection/env,
-              k8sattributes,
-              batch,
-            ]
+            - memory_limiter
+            - resource
+            - resourcedetection/env
+            - k8sattributes
+            - batch
           exporters: [elasticsearch]
 
 ## Component scraping the kube api server

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -262,7 +262,7 @@ logsCollector:
   name: logs
   clusterName: ""
   image: otel/opentelemetry-collector-contrib:0.80.0
-  enabled: false
+  enabled: true
   mode: daemonset
   resources:
     limits:
@@ -379,6 +379,15 @@ logsCollector:
         send_batch_size: 1000
         timeout: 1s
         send_batch_max_size: 1500
+      metricstransform/k8sservicename:
+        transforms:
+          - include: kube_service_info
+            match_type: strict
+            action: update
+            operations:
+              - action: update_label
+                label: service
+                new_label: k8s.service.name
       k8sattributes:
         passthrough: false
         pod_association:
@@ -419,6 +428,10 @@ logsCollector:
         index: "lightstep"
         headers:
           "lightstep-access-token": "${LS_TOKEN}"
+      otlp:
+        endpoint: ingest.lightstep.com:443
+        headers:
+          "lightstep-access-token": "${LS_TOKEN}"
 
     service:
       pipelines:
@@ -431,6 +444,17 @@ logsCollector:
             - k8sattributes
             - batch
           exporters: [elasticsearch]
+        # include self-scraped metrics, see `templates/collector.yaml` for `prometheus` receiver definition
+        metrics:
+          receivers: [prometheus]
+          processors:
+            - memory_limiter
+            - resource
+            - resourcedetection/env
+            - k8sattributes
+            - metricstransform/k8sservicename
+            - batch
+          exporters: [otlp]
 
 ## Component scraping the kube api server
 ##

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -388,7 +388,6 @@ logsCollector:
                 name: k8s.pod.name
         extract:
           metadata:
-            - k8s.cluster.name
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.pod.uid
@@ -420,7 +419,7 @@ logsCollector:
         endpoints: ["https://logingest.lightstep.com"]
         index: "lightstep"
         headers:
-          "lightstep-access-token": "${LS_ACCESS_TOKEN}"
+          "lightstep-access-token": "${LS_TOKEN}"
 
     service:
       pipelines:

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -265,7 +265,7 @@ metricsCollector:
 logsCollector:
   name: logs
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.76.3
+  image: otel/opentelemetry-collector-contrib:latest
   enabled: false
   mode: daemonset
   resources:

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -109,12 +109,12 @@ tracesCollector:
             - container.image.name
       resource:
         attributes:
-        - key: lightstep.helm_chart
-          value: kube-otel-stack
-          action: insert
-        - key: collector.name
-          value: "${KUBE_POD_NAME}"
-          action: insert
+          - key: lightstep.helm_chart
+            value: kube-otel-stack
+            action: insert
+          - key: collector.name
+            value: "${KUBE_POD_NAME}"
+            action: insert
 
     exporters:
       otlp:
@@ -126,7 +126,14 @@ tracesCollector:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, resource, resourcedetection/env, k8sattributes, batch]
+          processors:
+            [
+              memory_limiter,
+              resource,
+              resourcedetection/env,
+              k8sattributes,
+              batch,
+            ]
           exporters: [otlp]
 
 ## Default collector for metrics (includes infrastructure metrics)
@@ -222,15 +229,15 @@ metricsCollector:
         send_batch_max_size: 1500
       resource:
         attributes:
-        - key: lightstep.helm_chart
-          value: kube-otel-stack
-          action: insert
-        - key: collector.name
-          value: "${KUBE_POD_NAME}"
-          action: insert
-        - key: job
-          from_attribute: service.name
-          action: insert
+          - key: lightstep.helm_chart
+            value: kube-otel-stack
+            action: insert
+          - key: collector.name
+            value: "${KUBE_POD_NAME}"
+            action: insert
+          - key: job
+            from_attribute: service.name
+            action: insert
 
     exporters:
       otlp:
@@ -244,8 +251,190 @@ metricsCollector:
       pipelines:
         metrics:
           receivers: [prometheus, otlp]
-          processors: [memory_limiter, resource, resourcedetection/env, k8sattributes, metricstransform/k8sservicename, batch]
+          processors:
+            [
+              memory_limiter,
+              resource,
+              resourcedetection/env,
+              k8sattributes,
+              metricstransform/k8sservicename,
+              batch,
+            ]
           exporters: [otlp]
+
+logsCollector:
+  name: logs
+  clusterName: ""
+  image: otel/opentelemetry-collector-contrib:0.76.3
+  enabled: true
+  mode: daemonset
+  resources:
+    limits:
+      cpu: 250m
+      memory: 250Mi
+    requests:
+      cpu: 250m
+      memory: 250Mi
+  env:
+    - name: LS_TOKEN
+      valueFrom:
+        secretKeyRef:
+          key: LS_TOKEN
+          name: otel-collector-secret
+  volumeMounts:
+    - mountPath: /var/log
+      name: varlog
+      readOnly: true
+    - mountPath: /var/lib/docker/containers
+      name: varlibdockercontainers
+      readOnly: true
+  terminationGracePeriodSeconds: 30
+  volumes:
+    - name: varlog
+      hostPath:
+        path: /var/log
+    - name: varlibdockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+  config:
+    receivers:
+      filelog:
+        include:
+          - /var/log/pods/*/*/*.log
+        exclude:
+          # Exclude logs from all containers named otel-collector
+          - /var/log/pods/*/otel-collector/*.log
+        start_at: beginning
+        include_file_path: true
+        include_file_name: false
+        operators:
+          # Find out which format is used by kubernetes
+          - type: router
+            id: get-format
+            routes:
+              - output: parser-docker
+                expr: '$$record matches "^\\{"'
+              - output: parser-crio
+                expr: '$$record matches "^[^ Z]+ "'
+              - output: parser-containerd
+                expr: '$$record matches "^[^ Z]+Z"'
+          # Parse CRI-O format
+          - type: regex_parser
+            id: parser-crio
+            regex: "^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$"
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: time
+              layout_type: gotime
+              layout: "2006-01-02T15:04:05.000000000-07:00"
+          # Parse CRI-Containerd format
+          - type: regex_parser
+            id: parser-containerd
+            regex: "^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$"
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: time
+              layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+          # Parse Docker format
+          - type: json_parser
+            id: parser-docker
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: time
+              layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+          # Extract metadata from file path
+          - type: regex_parser
+            id: extract_metadata_from_filepath
+            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$'
+            parse_from: $$attributes.file_path
+          # Move out attributes to Attributes
+          - type: metadata
+            attributes:
+              stream: "EXPR($.stream)"
+              k8s.container.name: "EXPR($.container_name)"
+              k8s.namespace.name: "EXPR($.namespace)"
+              k8s.pod.name: "EXPR($.pod_name)"
+              run_id: "EXPR($.run_id)"
+              k8s.pod.uid: "EXPR($.uid)"
+          # Clean up log record
+          - type: restructure
+            id: clean-up-log-record
+            ops:
+              - remove: logtag
+              - remove: stream
+              - remove: container_name
+              - remove: namespace
+              - remove: pod_name
+              - remove: run_id
+              - remove: uid
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 30
+      resourcedetection/env:
+        detectors: [env]
+        timeout: 2s
+        override: false
+      batch:
+        send_batch_size: 1000
+        timeout: 1s
+        send_batch_max_size: 1500
+      k8sattributes:
+        passthrough: false
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+        extract:
+          metadata:
+            - k8s.cluster.name
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.node.name
+            - k8s.pod.start_time
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.replicaset.uid
+            - k8s.daemonset.name
+            - k8s.daemonset.uid
+            - k8s.job.name
+            - k8s.job.uid
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+            - k8s.statefulset.uid
+            - container.image.tag
+            - container.image.name
+      resource:
+        attributes:
+          - key: lightstep.helm_chart
+            value: kube-otel-stack
+            action: insert
+          - key: collector.name
+            value: "${KUBE_POD_NAME}"
+            action: insert
+
+    exporters:
+      elasticsearch:
+        endpoints: ["https://logingest.lightstep.com"]
+        index: "lightstep"
+        headers:
+          "lightstep-access-token": "${LS_ACCESS_TOKEN}"
+
+    service:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors:
+            [
+              memory_limiter,
+              resource,
+              resourcedetection/env,
+              k8sattributes,
+              batch,
+            ]
+          exporters: [elasticsearch]
 
 ## Component scraping the kube api server
 ##
@@ -342,27 +531,27 @@ kubelet:
       # Drop less useful container CPU metrics.
       - sourceLabels: [__name__]
         action: drop
-        regex: 'container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)'
+        regex: "container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)"
       # Drop less useful container / always zero filesystem metrics.
       - sourceLabels: [__name__]
         action: drop
-        regex: 'container_fs_(io_current|io_time_seconds_total|io_time_weighted_seconds_total|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)'
+        regex: "container_fs_(io_current|io_time_seconds_total|io_time_weighted_seconds_total|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)"
       # Drop less useful / always zero container memory metrics.
       - sourceLabels: [__name__]
         action: drop
-        regex: 'container_memory_(mapped_file|swap)'
+        regex: "container_memory_(mapped_file|swap)"
       # Drop less useful container process metrics.
       - sourceLabels: [__name__]
         action: drop
-        regex: 'container_(file_descriptors|tasks_state|threads_max)'
+        regex: "container_(file_descriptors|tasks_state|threads_max)"
       # Drop container spec metrics that overlap with kube-state-metrics.
       - sourceLabels: [__name__]
         action: drop
-        regex: 'container_spec.*'
+        regex: "container_spec.*"
       # Drop cgroup metrics with no pod.
       - sourceLabels: [id, pod]
         action: drop
-        regex: '.+;'
+        regex: ".+;"
     # - sourceLabels: [__name__, image]
     #   separator: ;
     #   regex: container_([a-z_]+);

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -261,7 +261,7 @@ metricsCollector:
 logsCollector:
   name: logs
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.80.0
   enabled: false
   mode: daemonset
   resources:
@@ -294,12 +294,10 @@ logsCollector:
         path: /var/lib/docker/containers
   config:
     receivers:
+      # inspired by https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/081678933ad0246a0fcb9564c8f1871480a306aa/examples/kubernetes/otel-collector-config.yml
       filelog:
         include:
           - /var/log/pods/*/*/*.log
-        exclude:
-          # Exclude logs from all containers named otel-collector
-          - /var/log/pods/*/otel-collector/*.log
         start_at: beginning
         include_file_path: true
         include_file_name: false
@@ -309,60 +307,64 @@ logsCollector:
             id: get-format
             routes:
               - output: parser-docker
-                expr: '$$record matches "^\\{"'
+                expr: 'body matches "^\\{"'
               - output: parser-crio
-                expr: '$$record matches "^[^ Z]+ "'
+                expr: 'body matches "^[^ Z]+ "'
               - output: parser-containerd
-                expr: '$$record matches "^[^ Z]+Z"'
+                expr: 'body matches "^[^ Z]+Z"'
           # Parse CRI-O format
           - type: regex_parser
             id: parser-crio
-            regex: "^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$"
+            regex: "^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
             output: extract_metadata_from_filepath
             timestamp:
-              parse_from: time
+              parse_from: attributes.time
               layout_type: gotime
-              layout: "2006-01-02T15:04:05.000000000-07:00"
+              layout: "2006-01-02T15:04:05.999999999Z07:00"
           # Parse CRI-Containerd format
           - type: regex_parser
             id: parser-containerd
-            regex: "^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$"
+            regex: "^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
             output: extract_metadata_from_filepath
             timestamp:
-              parse_from: time
+              parse_from: attributes.time
               layout: "%Y-%m-%dT%H:%M:%S.%LZ"
           # Parse Docker format
           - type: json_parser
             id: parser-docker
             output: extract_metadata_from_filepath
             timestamp:
-              parse_from: time
+              parse_from: attributes.time
               layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+          - type: move
+            from: attributes.log
+            to: body
           # Extract metadata from file path
           - type: regex_parser
             id: extract_metadata_from_filepath
-            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$'
-            parse_from: $$attributes.file_path
-          # Move out attributes to Attributes
-          - type: metadata
-            attributes:
-              stream: "EXPR($.stream)"
-              k8s.container.name: "EXPR($.container_name)"
-              k8s.namespace.name: "EXPR($.namespace)"
-              k8s.pod.name: "EXPR($.pod_name)"
-              run_id: "EXPR($.run_id)"
-              k8s.pod.uid: "EXPR($.uid)"
-          # Clean up log record
-          - type: restructure
-            id: clean-up-log-record
-            ops:
-              - remove: logtag
-              - remove: stream
-              - remove: container_name
-              - remove: namespace
-              - remove: pod_name
-              - remove: run_id
-              - remove: uid
+            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+            parse_from: attributes["log.file.path"]
+            cache:
+              size: 128 # default maximum amount of Pods per Node is 110
+          # Rename attributes
+          - type: move
+            from: attributes.stream
+            to: attributes["log.iostream"]
+          - type: move
+            from: attributes.container_name
+            to: resource["k8s.container.name"]
+          - type: move
+            from: attributes.namespace
+            to: resource["k8s.namespace.name"]
+          - type: move
+            from: attributes.pod_name
+            to: resource["k8s.pod.name"]
+          - type: move
+            from: attributes.restart_count
+            to: resource["k8s.container.restart_count"]
+          - type: move
+            from: attributes.uid
+            to: resource["k8s.pod.uid"]
     processors:
       memory_limiter:
         check_interval: 1s


### PR DESCRIPTION
This PR adds a `logsCollector` collector to the set of collectors for the kube-otel-stack chart, allowing users to have a one-line installation path for collecting metrics, traces, and logs.

Other minor formatting updates are included, which are based on the default VS Code YAML format recommendations. I thought they might be helpful since there is inconsistent formatting in different parts of the `values.yaml` file, but let me know if I should remove them.