### PR TITLE
Updates for log events PR

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.13
+version: 0.2.15
 appVersion: 0.73.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -130,6 +130,7 @@ rules:
   - services
   - endpoints
   - pods
+  - events
   verbs: ["get", "list", "watch"]
 - apiGroups: ["monitoring.coreos.com"]
   resources:

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -294,7 +294,7 @@ logsCollector:
         path: /var/lib/docker/containers
   config:
     receivers:
-       k8s_events:
+      k8s_events: {}
       # inspired by https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/081678933ad0246a0fcb9564c8f1871480a306aa/examples/kubernetes/otel-collector-config.yml
       filelog:
         include:
@@ -437,7 +437,7 @@ logsCollector:
     service:
       pipelines:
         logs:
-          receivers: [k8s_events,filelog]
+          receivers: [k8s_events, filelog]
           processors:
             - memory_limiter
             - resource


### PR DESCRIPTION
Fixes for https://github.com/lightstep/otel-collector-charts/pull/25:

- Bumps chart version
- Adds `events` permission to RBAC cluster role
- Fixes an indentation issue