### PR TITLE
Add kube_app_* labels for metrics, logs, and traces

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.15
+version: 0.2.16
 appVersion: 0.80.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -89,6 +89,11 @@ tracesCollector:
               - from: resource_attribute
                 name: k8s.pod.name
         extract:
+          labels:
+            - tag_name: kube_app_$$1
+              key_regex: ^app\.kubernetes\.io/([a-zA-Z0-9_-]+)
+            - tag_name: app
+              key: app
           metadata:
             - k8s.namespace.name
             - k8s.pod.name
@@ -203,6 +208,11 @@ metricsCollector:
               - from: resource_attribute
                 name: k8s.pod.name
         extract:
+          labels:
+            - tag_name: kube_app_$$1
+              key_regex: ^app\.kubernetes\.io/([a-zA-Z0-9_-]+)
+            - tag_name: app
+              key: app
           metadata:
             - k8s.namespace.name
             - k8s.pod.name
@@ -396,6 +406,11 @@ logsCollector:
               - from: resource_attribute
                 name: k8s.pod.name
         extract:
+          labels:
+            - tag_name: kube_app_$$1
+              key_regex: ^app\.kubernetes\.io/([a-zA-Z0-9_-]+)
+            - tag_name: app
+              key: app
           metadata:
             - k8s.namespace.name
             - k8s.pod.name

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -90,10 +90,18 @@ tracesCollector:
                 name: k8s.pod.name
         extract:
           labels:
-            - tag_name: kube_app_$$1
-              key_regex: ^app\.kubernetes\.io/([a-zA-Z0-9_-]+)
-            - tag_name: app
-              key: app
+            - tag_name: k8s.app.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: k8s.app.instance
+              key: app.kubernetes.io/instance
+              from: pod
+            - tag_name: k8s.app.version
+              key: app.kubernetes.io/version
+              from: pod
+            - tag_name: k8s.app.component
+              key: app.kubernetes.io/component
+              from: pod
           metadata:
             - k8s.namespace.name
             - k8s.pod.name
@@ -209,10 +217,18 @@ metricsCollector:
                 name: k8s.pod.name
         extract:
           labels:
-            - tag_name: kube_app_$$1
-              key_regex: ^app\.kubernetes\.io/([a-zA-Z0-9_-]+)
-            - tag_name: app
-              key: app
+            - tag_name: k8s.app.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: k8s.app.instance
+              key: app.kubernetes.io/instance
+              from: pod
+            - tag_name: k8s.app.version
+              key: app.kubernetes.io/version
+              from: pod
+            - tag_name: k8s.app.component
+              key: app.kubernetes.io/component
+              from: pod
           metadata:
             - k8s.namespace.name
             - k8s.pod.name
@@ -407,10 +423,18 @@ logsCollector:
                 name: k8s.pod.name
         extract:
           labels:
-            - tag_name: kube_app_$$1
-              key_regex: ^app\.kubernetes\.io/([a-zA-Z0-9_-]+)
-            - tag_name: app
-              key: app
+            - tag_name: k8s.app.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: k8s.app.instance
+              key: app.kubernetes.io/instance
+              from: pod
+            - tag_name: k8s.app.version
+              key: app.kubernetes.io/version
+              from: pod
+            - tag_name: k8s.app.component
+              key: app.kubernetes.io/component
+              from: pod
           metadata:
             - k8s.namespace.name
             - k8s.pod.name


### PR DESCRIPTION
* Adds `kube_app_*` labels for metrics, logs, and traces from https://kubernetes.io/docs/reference/labels-annotations-taints/

Open question... what do the OTel semantic conventions say about this?