### PR TITLE
New chart for Kubernetes metrics via native recievers

### DIFF
--- a/charts/collector-k8s-noprom/.helmignore
+++ b/charts/collector-k8s-noprom/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/collector-k8s-noprom/Chart.yaml
+++ b/charts/collector-k8s-noprom/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: collector-k8s-noprom
+description: Use OpenTelemetry Collector to pull k8s metrics without Prometheus
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/collector-k8s-noprom/templates/NOTES.txt
+++ b/charts/collector-k8s-noprom/templates/NOTES.txt
@@ -1,0 +1,1 @@
+collector-k8s-noprom

--- a/charts/collector-k8s-noprom/templates/collector.yaml
+++ b/charts/collector-k8s-noprom/templates/collector.yaml
@@ -1,0 +1,118 @@
+{{ range $_, $collector := .Values.collectors -}}
+{{ if $collector.enabled }}
+{{ $collectorName := (print $.Release.Name "-" $collector.name) }}
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: "{{ $collectorName }}"
+spec:
+  mode: {{ $collector.mode }}
+  image: {{ $collector.image }}
+  replicas: {{ $collector.replicas | default 1 }}
+  ports:
+    - name: "metrics"
+      protocol: TCP
+      port: 8888
+  env:
+    {{- toYaml $collector.env | nindent 4}}
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+  config: |
+    exporters:
+      {{- toYaml $collector.config.exporters | nindent 6 }}
+    receivers:
+      {{- toYaml $collector.config.receivers | nindent 6 }}
+    processors:
+      {{- toYaml $collector.config.processors | nindent 6 }}
+    service:
+      {{- toYaml $collector.config.service | nindent 6 }}
+  resources:
+    {{- toYaml $collector.resources | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ $collectorName }}"
+rules:
+- apiGroups: [""]
+  resources:
+    - events
+    - namespaces
+    - namespaces/status
+    - nodes
+    - nodes/spec
+    - nodes/stats
+    - nodes/proxy
+    - pods
+    - pods/status
+    - replicationcontrollers
+    - replicationcontrollers/status
+    - resourcequotas
+    - services
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - cronjobs
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - ingresses
+    - daemonsets
+    - deployments
+    - replicasets
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+    - deployments
+    - replicasets
+    - statefulsets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - networking.k8s.io
+  resources:
+    - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ $collectorName }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ $collectorName }}"
+subjects:
+- kind: ServiceAccount
+  # quirk of the Operator
+  name: "{{ $collectorName }}-collector"
+  namespace: {{ $.Release.Namespace }}
+---
+{{ end }}
+{{- end }}

--- a/charts/collector-k8s-noprom/templates/collector.yaml
+++ b/charts/collector-k8s-noprom/templates/collector.yaml
@@ -23,6 +23,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: "k8s.cluster.name={{ $collector.clusterName | default "unknown" }}"
   config: |
     exporters:
       {{- toYaml $collector.config.exporters | nindent 6 }}

--- a/charts/collector-k8s-noprom/values.yaml
+++ b/charts/collector-k8s-noprom/values.yaml
@@ -39,6 +39,10 @@ collectors:
             - pod
             - container
       processors:
+        resourcedetection/env:
+          detectors: [env]
+          timeout: 2s
+          override: false
         k8sattributes:
           filter:
             node_from_env_var: K8S_NODE_NAME
@@ -81,7 +85,7 @@ collectors:
 
       exporters:
         logging:
-          verbosity: detailed
+          verbosity: normal
           sampling_initial: 5
           sampling_thereafter: 200
         otlp:
@@ -97,12 +101,12 @@ collectors:
             exporters: [otlp]
           metrics/kubelet:
             receivers: [kubeletstats]
-            processors: [memory_limiter, k8sattributes, batch]
+            processors: [memory_limiter, resourcedetection/env, k8sattributes, batch]
             exporters: [logging, otlp]
 
   # collect cluster-level metrics
   - name: cluster-stats
-    image: otel/opentelemetry-collector-contrib:0.81.0
+    image: otel/opentelemetry-collector-contrib:0.80.0
     replicas: 1
     enabled: true
     resources:
@@ -133,13 +137,18 @@ collectors:
                 targets:
                   - 0.0.0.0:8888
         k8s_cluster:
+          auth_type: serviceAccount
           collection_interval: 10s
-          node_conditions_to_report: [Ready,MemoryPressure,DiskPressure,NetworkUnavailable]
-          allocatable_types_to_report: [cpu,memory,storage]
+          node_conditions_to_report: [Ready, MemoryPressure, DiskPressure, NetworkUnavailable]
+          allocatable_types_to_report: [cpu, memory, storage]
         k8s_events:
-          auth_type : serviceAccount
-      
+          auth_type: serviceAccount
+
       processors:
+        resourcedetection/env:
+          detectors: [env]
+          timeout: 2s
+          override: false
         memory_limiter:
           check_interval: 1s
           limit_percentage: 75
@@ -148,7 +157,7 @@ collectors:
           send_batch_size: 1000
           timeout: 1s
           send_batch_max_size: 1500
-      
+
       exporters:
         logging:
           verbosity: normal
@@ -158,19 +167,14 @@ collectors:
           endpoint: ingest.lightstep.com:443
           headers:
             "lightstep-access-token": "${LS_TOKEN}"
-            
+
       service:
         pipelines:
-          # TODO: seperate collector preferred (?)
-          #logs:
-          #  receivers: [k8s_cluster]
-          #  processors: [memory_limiter, batch]
-          #  exporters: [otlp]
           metrics/collector:
             receivers: [prometheus]
             processors: [memory_limiter, batch]
             exporters: [otlp]
           metrics/k8s_cluster:
             receivers: [k8s_cluster]
-            processors: [memory_limiter, batch]
+            processors: [memory_limiter, resourcedetection/env, batch]
             exporters: [otlp, logging]

--- a/charts/collector-k8s-noprom/values.yaml
+++ b/charts/collector-k8s-noprom/values.yaml
@@ -1,0 +1,144 @@
+collectors:
+  # collect kubelet stats from each node
+  - name: kubelet-stats
+    image: otel/opentelemetry-collector-contrib:0.81.0
+    enabled: true
+    mode: daemonset
+    resources:
+      limits:
+        cpu: 500m
+        memory: 500Mi
+      requests:
+        cpu: 128m
+        memory: 128M
+    env:
+      - name: LS_TOKEN
+        valueFrom:
+          secretKeyRef:
+            key: LS_TOKEN
+            name: otel-collector-secret
+    config:
+      receivers:
+        prometheus:
+          config:
+            scrape_configs:
+            - job_name: otel-collector
+              scrape_interval: 5s
+              static_configs:
+              - labels:
+                  collector_name: ${KUBE_POD_NAME}
+                targets:
+                  - 0.0.0.0:8888
+        kubeletstats:
+          collection_interval: 10s
+          auth_type: "serviceAccount"
+          endpoint: "https://${K8S_NODE_NAME}:10250"
+          insecure_skip_verify: true
+          metric_groups:
+            - node
+            - pod
+            - container
+      processors:
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 2000
+        batch:
+          send_batch_size: 1000
+          timeout: 1s
+          send_batch_max_size: 1500
+
+      exporters:
+        logging:
+          verbosity: normal
+          sampling_initial: 5
+          sampling_thereafter: 200
+        otlp:
+          endpoint: ingest.lightstep.com:443
+          headers:
+            "lightstep-access-token": "${LS_TOKEN}"
+
+      service:
+        pipelines:
+          metrics/collector:
+            receivers: [prometheus]
+            processors: [memory_limiter, batch]
+            exporters: [logging, otlp]
+          metrics/kubelet:
+            receivers: [kubeletstats]
+            processors: [memory_limiter, batch]
+            exporters: [logging, otlp]
+
+  # collect cluster-level metrics
+  - name: cluster-stats
+    image: otel/opentelemetry-collector-contrib:0.81.0
+    replicas: 1
+    enabled: true
+    resources:
+      limits:
+        cpu: 500m
+        memory: 500Mi
+      requests:
+        cpu: 500m
+        memory: 500Mi
+    env:
+      - name: LS_TOKEN
+        valueFrom:
+          secretKeyRef:
+            key: LS_TOKEN
+            name: otel-collector-secret
+    config:
+      receivers:
+        # Prometheus receiver used for reporting collector health metrics
+        # TODO: replace with OTLP metrics when merged
+        prometheus:
+          config:
+            scrape_configs:
+            - job_name: otel-collector
+              scrape_interval: 5s
+              static_configs:
+              - labels:
+                  collector_name: ${KUBE_POD_NAME}
+                targets:
+                  - 0.0.0.0:8888
+        k8s_cluster:
+          collection_interval: 10s
+          node_conditions_to_report: [Ready,MemoryPressure,DiskPressure,NetworkUnavailable]
+          allocatable_types_to_report: [cpu,memory,storage]
+        k8s_events:
+          auth_type : serviceAccount
+      
+      processors:
+        memory_limiter:
+          check_interval: 1s
+          limit_percentage: 75
+          spike_limit_percentage: 30
+        batch:
+          send_batch_size: 1000
+          timeout: 1s
+          send_batch_max_size: 1500
+      
+      exporters:
+        logging:
+          verbosity: normal
+          sampling_initial: 5
+          sampling_thereafter: 200
+        otlp:
+          endpoint: ingest.lightstep.com:443
+          headers:
+            "lightstep-access-token": "${LS_TOKEN}"
+            
+      service:
+        pipelines:
+          # TODO: seperate collector preferred (?)
+          #logs:
+          #  receivers: [k8s_cluster]
+          #  processors: [memory_limiter, batch]
+          #  exporters: [otlp]
+          metrics/collector:
+            receivers: [prometheus]
+            processors: [memory_limiter, batch]
+            exporters: [otlp]
+          metrics/k8s_cluster:
+            receivers: [k8s_cluster]
+            processors: [memory_limiter, batch]
+            exporters: [otlp, logging]

--- a/charts/collector-k8s-noprom/values.yaml
+++ b/charts/collector-k8s-noprom/values.yaml
@@ -39,6 +39,38 @@ collectors:
             - pod
             - container
       processors:
+        k8sattributes:
+          filter:
+            node_from_env_var: K8S_NODE_NAME
+          pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+          extract:
+            labels:
+            - tag_name: service.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: k8s.app.instance
+              key: app.kubernetes.io/instance
+              from: pod
+            - tag_name: service.version
+              key: app.kubernetes.io/version
+              from: pod
+            - tag_name: k8s.app.component
+              key: app.kubernetes.io/component
+              from: pod
+            metadata:
+              - k8s.deployment.name
+              - k8s.replicaset.name
+              - k8s.replicaset.uid
+              - k8s.daemonset.name
+              - k8s.daemonset.uid
+              - k8s.job.name
+              - k8s.job.uid
+              - k8s.cronjob.name
+              - k8s.statefulset.name
+              - k8s.statefulset.uid
         memory_limiter:
           check_interval: 1s
           limit_mib: 2000
@@ -49,7 +81,7 @@ collectors:
 
       exporters:
         logging:
-          verbosity: normal
+          verbosity: detailed
           sampling_initial: 5
           sampling_thereafter: 200
         otlp:
@@ -62,10 +94,10 @@ collectors:
           metrics/collector:
             receivers: [prometheus]
             processors: [memory_limiter, batch]
-            exporters: [logging, otlp]
+            exporters: [otlp]
           metrics/kubelet:
             receivers: [kubeletstats]
-            processors: [memory_limiter, batch]
+            processors: [memory_limiter, k8sattributes, batch]
             exporters: [logging, otlp]
 
   # collect cluster-level metrics


### PR DESCRIPTION
Chart that pulls kubernetes metrics from collector-native receivers.
* kubelet stats: deployed as agent on each Kubernetes host
* cluster-level stats: deployed once per cluster
