### PR TITLE
Add k8s.cluster.uid, bump version to v0.83.0

### DIFF
--- a/charts/collector-k8s-noprom/Chart.yaml
+++ b/charts/collector-k8s-noprom/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/collector-k8s-noprom/templates/NOTES.txt
+++ b/charts/collector-k8s-noprom/templates/NOTES.txt
@@ -1,1 +1,15 @@
-collector-k8s-noprom
+=======================================================================================
+ _   _______ _____  ___  ___     _        _          
+| | / /  _  /  ___| |  \/  |    | |      (_)         
+| |/ / \ V /\ `--.  | .  . | ___| |_ _ __ _  ___ ___ 
+|    \ / _ \ `--. \ | |\/| |/ _ \ __| '__| |/ __/ __|
+| |\  \ |_| /\__/ / | |  | |  __/ |_| |  | | (__\__ \
+\_| \_|_____|____/  \_|  |_/\___|\__|_|  |_|\___|___/
+
+- Your cluster is now sending metrics to ServiceNow Cloud Observability!
+
+- View collector logs by running:
+  kubectl logs deployment/collector-k8s-noprom-cluster-stats-collector
+
+- Create a ServiceNow Cloud Observability dashboard to visualize your metrics
+  by visiting: https://app.lightstep.com

--- a/charts/collector-k8s-noprom/values.yaml
+++ b/charts/collector-k8s-noprom/values.yaml
@@ -1,7 +1,7 @@
 collectors:
   # collect kubelet stats from each node
   - name: kubelet-stats
-    image: otel/opentelemetry-collector-contrib:0.81.0
+    image: otel/opentelemetry-collector-contrib:0.83.0
     enabled: true
     mode: daemonset
     resources:
@@ -75,6 +75,7 @@ collectors:
               - k8s.cronjob.name
               - k8s.statefulset.name
               - k8s.statefulset.uid
+              - k8s.cluster.uid
         memory_limiter:
           check_interval: 1s
           limit_mib: 2000
@@ -106,7 +107,7 @@ collectors:
 
   # collect cluster-level metrics
   - name: cluster-stats
-    image: otel/opentelemetry-collector-contrib:0.80.0
+    image: otel/opentelemetry-collector-contrib:0.83.0
     replicas: 1
     enabled: true
     resources:
@@ -145,6 +146,10 @@ collectors:
           auth_type: serviceAccount
 
       processors:
+        k8sattributes:
+          extract:
+            metadata:
+              - k8s.cluster.uid
         resourcedetection/env:
           detectors: [env]
           timeout: 2s
@@ -176,5 +181,5 @@ collectors:
             exporters: [otlp]
           metrics/k8s_cluster:
             receivers: [k8s_cluster]
-            processors: [memory_limiter, resourcedetection/env, batch]
+            processors: [memory_limiter, resourcedetection/env, k8sattributes, batch]
             exporters: [otlp, logging]

--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.15
+version: 0.2.16
 appVersion: 0.80.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -262,7 +262,7 @@ metricsCollector:
 logsCollector:
   name: logs
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.80.0
+  image: otel/opentelemetry-collector-contrib:0.83.0
   enabled: false
   mode: daemonset
   resources:
@@ -398,6 +398,7 @@ logsCollector:
                 name: k8s.pod.name
         extract:
           metadata:
+            - k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.pod.uid

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -47,7 +47,7 @@ tracesCollector:
   enabled: false
   name: traces
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.80.0
+  image: otel/opentelemetry-collector-contrib:0.83.0
   mode: deployment
   replicas: 1
   resources:
@@ -90,6 +90,7 @@ tracesCollector:
                 name: k8s.pod.name
         extract:
           metadata:
+            - k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.pod.uid


### PR DESCRIPTION
* Adds some ASCII art and instructions of what to do after installing the chart.
* adds `k8s.cluster.uid` (added in v0.83.0) to k8sattributes pipelines