### PR TITLE
fix(collector): Include secrets in clusterrole

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.16
+version: 0.2.17
 appVersion: 0.80.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -131,6 +131,7 @@ rules:
   - endpoints
   - pods
   - events
+  - secrets
   verbs: ["get", "list", "watch"]
 - apiGroups: ["monitoring.coreos.com"]
   resources:


### PR DESCRIPTION
Include `secrets` resource in clusterrole.

```console
ServiceMonitor","serviceMonitor":"prometheus-operator-operator","error":"failed to get CA: unable to get secret \"prometheus-operator-admission\": secrets \"prometheus-operator-admission\" is forbidden: User \"system:serviceaccount:opentelemetry-operator-system:kube-otel-stack-metrics-collector\" cannot get resource \"secrets\" in API group \"\" in the namespace \"monitoring\"","errorVerbose":"secrets \"prometheus-operator-admission\" is forbidden: 

```