### PR TITLE
Move to OTLP log ingest instead of using the Elasticsearch exporter

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.18
+version: 0.2.19
 appVersion: 0.80.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.19
+version: 0.2.20
 appVersion: 0.80.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -431,11 +431,6 @@ logsCollector:
             action: insert
 
     exporters:
-      elasticsearch:
-        endpoints: ["https://logingest.lightstep.com"]
-        index: "lightstep"
-        headers:
-          "lightstep-access-token": "${LS_TOKEN}"
       otlp:
         endpoint: ingest.lightstep.com:443
         headers:
@@ -451,7 +446,7 @@ logsCollector:
             - resourcedetection/env
             - k8sattributes
             - batch
-          exporters: [elasticsearch]
+          exporters: [otlp]
         # include self-scraped metrics, see `templates/collector.yaml` for `prometheus` receiver definition
         metrics:
           receivers: [prometheus]


### PR DESCRIPTION
This changes updates the `logsCollector` configuration to use the OTLP gRPC format when sending logs to SNCO, replacing the Elasticsearch exporter.