### PR TITLE
fix(targetAllocator): Include container resources for targetAllocator

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.18
+version: 0.2.19
 appVersion: 0.80.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -40,6 +40,10 @@ spec:
     image: {{ $collector.targetallocator.image }}
     replicas: {{ $collector.targetallocator.replicas }}
     allocationStrategy: {{ $collector.targetallocator.allocationStrategy }}
+    {{- if $collector.targetallocator.resources }}
+    resources:
+      {{- toYaml $collector.targetallocator.resources | nindent 6 }}
+    {{- end }}
     {{- if $collector.targetallocator.filterStrategy }}
     filterStrategy: {{ $collector.targetallocator.filterStrategy }}
     {{- end }}

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -155,13 +155,14 @@ metricsCollector:
     image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.80.0
     prometheusCR:
       enabled: true
-    resources:
-      limits:
-        cpu: 200m
-        memory: 500Mi
-      requests:
-        cpu: 100m
-        memory: 250Mi
+    # Override Default targetAllocator resources
+    # resources:
+    #   limits:
+    #     cpu: 200m
+    #     memory: 500Mi
+    #   requests:
+    #     cpu: 100m
+    #     memory: 250Mi
   # No need for a scrape config when using prometheusCRs
   scrape_configs_file: "scrape_configs.yaml"
   resources:

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -155,6 +155,13 @@ metricsCollector:
     image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.80.0
     prometheusCR:
       enabled: true
+    resources:
+      limits:
+        cpu: 200m
+        memory: 500Mi
+      requests:
+        cpu: 100m
+        memory: 250Mi
   # No need for a scrape config when using prometheusCRs
   scrape_configs_file: "scrape_configs.yaml"
   resources:


### PR DESCRIPTION
Small default resource for targetAllocator is being OOM terminated by kubernetes.
 
- Add resources spec to helm chart for targetAllocator so defaults can be overridden.
- Bump chart to 0.2.19