### PR TITLE
Add logging collector to otel-cloud-stack chart

### DIFF
--- a/charts/otel-cloud-stack/Chart.yaml
+++ b/charts/otel-cloud-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/otel-cloud-stack/templates/collector.yaml
+++ b/charts/otel-cloud-stack/templates/collector.yaml
@@ -1,4 +1,4 @@
-{{ $collectorList := concat .Values.collectors (list .Values.daemonCollector .Values.clusterCollector .Values.tracesCollector) }}
+{{ $collectorList := concat .Values.collectors (list .Values.daemonCollector .Values.clusterCollector .Values.tracesCollector .Values.logsCollector ) }}
 {{ range $_, $collector := $collectorList -}}
 {{ if $collector.enabled }}
 {{ $collectorName := (print $.Release.Name "-" $collector.name) }}
@@ -70,12 +70,18 @@ spec:
       readOnly: true
       mountPropagation: HostToContainer
     {{- end }}
+    {{- if $collector.volumeMounts }}
+      {{- toYaml $collector.volumeMounts | nindent 4 }}
+    {{- end }}
   volumes:
     {{- if $collector.mountHostFS }}
     - name: hostfs
       hostPath:
         path: /
     {{- end }}
+    {{- if $collector.volumes }}
+      {{- toYaml $collector.volumes | nindent 4 }}
+    {{ end }}
   env:
     {{- if or $collector.env $.Values.extraEnvs }}
     {{- toYaml (concat $.Values.extraEnvs $collector.env) | nindent 4 }}

--- a/charts/otel-cloud-stack/values.yaml
+++ b/charts/otel-cloud-stack/values.yaml
@@ -618,14 +618,6 @@ logsCollector:
             - k8s.statefulset.uid
             - container.image.tag
             - container.image.name
-      resource:
-        attributes:
-          - key: lightstep.helm_chart
-            value: kube-otel-stack
-            action: insert
-          - key: collector.name
-            value: "${KUBE_POD_NAME}"
-            action: insert
 
     exporters:
       otlp:

--- a/charts/otel-cloud-stack/values.yaml
+++ b/charts/otel-cloud-stack/values.yaml
@@ -471,4 +471,178 @@ tracesCollector:
             - batch
           exporters: [otlp]
 
+logsCollector:
+  enabled: false
+  name: logs
+  clusterName: ""
+  image: otel/opentelemetry-collector-contrib:0.83.0
+  mode: daemonset
+  resources:
+    limits:
+      cpu: 250m
+      memory: 250Mi
+    requests:
+      cpu: 250m
+      memory: 250Mi
+  env:
+    - name: LS_TOKEN
+      valueFrom:
+        secretKeyRef:
+          key: LS_TOKEN
+          name: otel-collector-secret
+  volumeMounts:
+    - mountPath: /var/log
+      name: varlog
+      readOnly: true
+    - mountPath: /var/lib/docker/containers
+      name: varlibdockercontainers
+      readOnly: true
+  volumes:
+    - name: varlog
+      hostPath:
+        path: /var/log
+    - name: varlibdockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+  config:
+    receivers:
+      k8s_events: {}
+      # inspired by https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/081678933ad0246a0fcb9564c8f1871480a306aa/examples/kubernetes/otel-collector-config.yml
+      filelog:
+        include:
+          - /var/log/pods/*/*/*.log
+        start_at: beginning
+        include_file_path: true
+        include_file_name: false
+        operators:
+          # Find out which format is used by kubernetes
+          - type: router
+            id: get-format
+            routes:
+              - output: parser-docker
+                expr: 'body matches "^\\{"'
+              - output: parser-crio
+                expr: 'body matches "^[^ Z]+ "'
+              - output: parser-containerd
+                expr: 'body matches "^[^ Z]+Z"'
+          # Parse CRI-O format
+          - type: regex_parser
+            id: parser-crio
+            regex: "^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: attributes.time
+              layout_type: gotime
+              layout: "2006-01-02T15:04:05.999999999Z07:00"
+          # Parse CRI-Containerd format
+          - type: regex_parser
+            id: parser-containerd
+            regex: "^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: attributes.time
+              layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+          # Parse Docker format
+          - type: json_parser
+            id: parser-docker
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: attributes.time
+              layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+          - type: move
+            from: attributes.log
+            to: body
+          # Extract metadata from file path
+          - type: regex_parser
+            id: extract_metadata_from_filepath
+            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+            parse_from: attributes["log.file.path"]
+            cache:
+              # default maximum amount of Pods per Node is 110
+              size: 128
+          # Rename attributes
+          - type: move
+            from: attributes.stream
+            to: attributes["log.iostream"]
+          - type: move
+            from: attributes.container_name
+            to: resource["k8s.container.name"]
+          - type: move
+            from: attributes.namespace
+            to: resource["k8s.namespace.name"]
+          - type: move
+            from: attributes.pod_name
+            to: resource["k8s.pod.name"]
+          - type: move
+            from: attributes.restart_count
+            to: resource["k8s.container.restart_count"]
+          - type: move
+            from: attributes.uid
+            to: resource["k8s.pod.uid"]
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 30
+      resourcedetection/env:
+        detectors: [env]
+        timeout: 2s
+        override: false
+      batch:
+        send_batch_size: 1000
+        timeout: 1s
+        send_batch_max_size: 1500
+      k8sattributes:
+        passthrough: false
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+        extract:
+          metadata:
+            - k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.node.name
+            - k8s.pod.start_time
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.replicaset.uid
+            - k8s.daemonset.name
+            - k8s.daemonset.uid
+            - k8s.job.name
+            - k8s.job.uid
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+            - k8s.statefulset.uid
+            - container.image.tag
+            - container.image.name
+      resource:
+        attributes:
+          - key: lightstep.helm_chart
+            value: kube-otel-stack
+            action: insert
+          - key: collector.name
+            value: "${KUBE_POD_NAME}"
+            action: insert
+
+    exporters:
+      otlp:
+        endpoint: ingest.lightstep.com:443
+        headers:
+          "lightstep-access-token": "${LS_TOKEN}"
+
+    service:
+      pipelines:
+        logs:
+          receivers: [k8s_events, filelog]
+          processors:
+            - memory_limiter
+            - resource
+            - resourcedetection/env
+            - k8sattributes
+            - batch
+          exporters: [otlp]
+
 collectors: []


### PR DESCRIPTION
This PR adds a logging collector section to the otel-cloud-stack values, allowing users to collect Kubernetes logs and events and send them to SN Cloud Observability by setting `logsCollector.enabled=true`.

_**Note**_ - I opted to create a new set of collectors for logging instead of piggybacking on the `daemonCollector`, even though they are both daemonsets. Let me know if we should merge the configs into that collector instead to avoid having two separate daemonsets.