### PR TITLE
Add option for setting `k8s.cluster.name` with otel-cloud-stack chart

### DIFF
--- a/charts/otel-cloud-stack/Chart.yaml
+++ b/charts/otel-cloud-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/otel-cloud-stack/templates/collector.yaml
+++ b/charts/otel-cloud-stack/templates/collector.yaml
@@ -108,6 +108,8 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: "k8s.cluster.name={{ $collector.clusterName | default "unknown" }}
   config: |
     exporters:
       {{- toYaml $collector.config.exporters | nindent 6 }}

--- a/charts/otel-cloud-stack/templates/collector.yaml
+++ b/charts/otel-cloud-stack/templates/collector.yaml
@@ -109,7 +109,7 @@ spec:
           apiVersion: v1
           fieldPath: status.podIP
     - name: OTEL_RESOURCE_ATTRIBUTES
-      value: "k8s.cluster.name={{ $collector.clusterName | default "unknown" }}
+      value: "k8s.cluster.name={{ $collector.clusterName | default "unknown" }}"
   config: |
     exporters:
       {{- toYaml $collector.config.exporters | nindent 6 }}

--- a/charts/otel-cloud-stack/values.yaml
+++ b/charts/otel-cloud-stack/values.yaml
@@ -38,6 +38,7 @@ autoinstrumentation:
 
 daemonCollector:
   name: daemon
+  clusterName: ""
   image: otel/opentelemetry-collector-contrib:0.83.0
   enabled: true
   mode: daemonset
@@ -233,6 +234,7 @@ daemonCollector:
 # This is a singleton collector for cluster-level data
 clusterCollector:
   name: cluster-stats
+  clusterName: ""
   image: otel/opentelemetry-collector-contrib:0.83.0
   replicas: 1
   enabled: true


### PR DESCRIPTION
Similar to kube-otel-stack chart, this PR allows setting a `clusterName` variable on a collector in order to have it emit a `k8s.cluster.name` attribute (or "unknown" if not otherwise set).