### PR TITLE
Remove memory_limiter from recommended OTel Collector configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ This is the repository for Lightstep's recommended [Helm](https://helm.sh/) char
 
 ## Charts
 
-* [collector-k8s](https://github.com/lightstep/prometheus-k8s-opentelemetry-collector/tree/main/charts/collector-k8s) - Chart for using the OpenTelemetry Collector to scape static or dynamic metric targets.
+* [collector-k8s](https://github.com/lightstep/prometheus-k8s-opentelemetry-collector/tree/main/charts/collector-k8s) - Chart for using the OpenTelemetry Collector to scrape static or dynamic metric targets.
 * [kube-otel-stack](https://github.com/lightstep/prometheus-k8s-opentelemetry-collector/tree/main/charts/kube-otel-stack) - Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 * [otel-cloud-stack](https://github.com/lightstep/prometheus-k8s-opentelemetry-collector/tree/main/charts/otel-cloud-stack) - Chart for sending Kubernetes metrics to Lightstep using Otel native metric collection and the OpenTelemetry Operator.

--- a/charts/collector-k8s/Chart.yaml
+++ b/charts/collector-k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: otelcollector
 description: Chart for using the OpenTelemetry Collector to scape static or dynamic metric targets.
 type: application
-version: 0.1.2
-appVersion: 0.61.0
+version: 0.2.0
+appVersion: 0.83.0
 dependencies:
 # cert manager must be manually installed because it has CRDs
 # https://github.com/kubernetes-sigs/security-profiles-operator/issues/1062

--- a/charts/collector-k8s/values-daemonset.yaml
+++ b/charts/collector-k8s/values-daemonset.yaml
@@ -24,9 +24,6 @@ collectors:
             grpc:
               endpoint: "0.0.0.0:4317"
       processors:
-        memory_limiter:
-          check_interval: 1s
-          limit_mib: 2000
         resourcedetection/gke:
           detectors: [env, gke]
           timeout: 2s
@@ -46,7 +43,7 @@ collectors:
         pipelines:
           metrics:
             receivers: [prometheus]
-            processors: [memory_limiter, resourcedetection/gke, batch]
+            processors: [resourcedetection/gke, batch]
             exporters: [otlp]
 
   # The daemonset collector should be configured to scrape general app metrics that contains `prometheus.io/scrape: true` annotation.
@@ -75,9 +72,6 @@ collectors:
             grpc:
               endpoint: "0.0.0.0:4317"
       processors:
-        memory_limiter:
-          check_interval: 1s
-          limit_mib: 2000
         resourcedetection/gke:
           detectors: [env, gke]
           timeout: 2s
@@ -97,5 +91,5 @@ collectors:
         pipelines:
           metrics:
             receivers: [prometheus]
-            processors: [memory_limiter, resourcedetection/gke, batch]
+            processors: [resourcedetection/gke, batch]
             exporters: [otlp]

--- a/charts/collector-k8s/values-statefulset.yaml
+++ b/charts/collector-k8s/values-statefulset.yaml
@@ -30,9 +30,6 @@ collectors:
             grpc:
               endpoint: "0.0.0.0:4317"
       processors:
-        memory_limiter:
-          check_interval: 1s
-          limit_percentage: 75
         resourcedetection/gke:
           detectors: [env, gke]
           timeout: 2s
@@ -57,5 +54,5 @@ collectors:
         pipelines:
           metrics:
             receivers: [prometheus]
-            processors: [memory_limiter, resourcedetection/gke, resource, batch]
+            processors: [resourcedetection/gke, resource, batch]
             exporters: [otlp]

--- a/charts/collector-k8s/values.yaml
+++ b/charts/collector-k8s/values.yaml
@@ -24,10 +24,6 @@ collectors:
             grpc:
               endpoint: "0.0.0.0:4317"
       processors:
-        memory_limiter:
-          check_interval: 1s
-          limit_percentage: 75
-          spike_limit_percentage: 30
         batch:
           send_batch_size: 1000
           timeout: 1s
@@ -43,9 +39,9 @@ collectors:
         pipelines:
           metrics:
             receivers: [prometheus]
-            processors: [memory_limiter, batch]
+            processors: [batch]
             exporters: [otlp]
           traces:
             receivers: [otlp]
-            processors: [memory_limiter, batch]
+            processors: [batch]
             exporters: [otlp]

--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.2.21
-appVersion: 0.80.0
+version: 0.3.0
+appVersion: 0.83.0
 dependencies:
 # cert manager must be manually installed because it has CRDs
 # https://github.com/kubernetes-sigs/security-profiles-operator/issues/1062

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -70,10 +70,6 @@ tracesCollector:
           grpc:
             endpoint: "0.0.0.0:4317"
     processors:
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 75
-        spike_limit_percentage: 30
       resourcedetection/env:
         detectors: [env]
         timeout: 2s
@@ -125,7 +121,6 @@ tracesCollector:
         traces:
           receivers: [otlp]
           processors:
-            - memory_limiter
             - resource
             - resourcedetection/env
             - k8sattributes
@@ -190,10 +185,6 @@ metricsCollector:
           grpc:
             endpoint: "0.0.0.0:4317"
     processors:
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 75
-        spike_limit_percentage: 30
       metricstransform/k8sservicename:
         transforms:
           - include: kube_service_info
@@ -258,7 +249,6 @@ metricsCollector:
         metrics:
           receivers: [prometheus, otlp]
           processors:
-            - memory_limiter
             - resource
             - resourcedetection/env
             - k8sattributes
@@ -376,10 +366,6 @@ logsCollector:
             from: attributes.uid
             to: resource["k8s.pod.uid"]
     processors:
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 75
-        spike_limit_percentage: 30
       resourcedetection/env:
         detectors: [env]
         timeout: 2s
@@ -440,7 +426,6 @@ logsCollector:
         logs:
           receivers: [k8s_events, filelog]
           processors:
-            - memory_limiter
             - resource
             - resourcedetection/env
             - k8sattributes
@@ -450,7 +435,6 @@ logsCollector:
         metrics:
           receivers: [prometheus]
           processors:
-            - memory_limiter
             - resource
             - resourcedetection/env
             - k8sattributes

--- a/charts/otel-cloud-stack/Chart.yaml
+++ b/charts/otel-cloud-stack/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: "0.2.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.17.0"

--- a/charts/otel-cloud-stack/values.yaml
+++ b/charts/otel-cloud-stack/values.yaml
@@ -129,10 +129,6 @@ daemonCollector:
           # process:
           network:
     processors:
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 85
-        spike_limit_percentage: 10
       resourcedetection/env:
         detectors: [env]
         timeout: 2s
@@ -221,7 +217,6 @@ daemonCollector:
           exporters:
             - otlp
           processors:
-            - memory_limiter
             - resourcedetection/env
             - k8sattributes
             - batch
@@ -328,10 +323,6 @@ clusterCollector:
         detectors: [env]
         timeout: 2s
         override: false
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 75
-        spike_limit_percentage: 30
       batch:
         send_batch_size: 1000
         timeout: 1s
@@ -351,7 +342,7 @@ clusterCollector:
       pipelines:
         metrics/k8s_cluster:
           receivers: [k8s_cluster]
-          processors: [memory_limiter, resourcedetection/env, k8sattributes, batch]
+          processors: [resourcedetection/env, k8sattributes, batch]
           exporters: [otlp, logging]
 
 ## Default collector for tracing
@@ -385,10 +376,6 @@ tracesCollector:
           grpc:
             endpoint: "0.0.0.0:4317"
     processors:
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 75
-        spike_limit_percentage: 30
       resourcedetection/env:
         detectors: [env]
         timeout: 2s
@@ -468,7 +455,6 @@ tracesCollector:
         traces:
           receivers: [otlp]
           processors:
-            - memory_limiter
             - resourcedetection/env
             - k8sattributes
             - batch


### PR DESCRIPTION
Lightstep has validated that telemetry pipelines without the memory_limiter are more reliable than with the memory_limiter. We emphatically do not recommend use of the OTel Collector memory_limiter component. 

The alternative to using memory_limiter is simply not to use memory_limiter. Instead, we recommend provisioning collectors with sufficient memory for typical load and the use of collector horizontal autoscaling to manage load balance.