### PR TITLE
LS-55580 Complete processing of log attributes

### DIFF
--- a/charts/otel-cloud-stack/Chart.yaml
+++ b/charts/otel-cloud-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.2.6"
+version: "0.2.7"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/otel-cloud-stack/values.yaml
+++ b/charts/otel-cloud-stack/values.yaml
@@ -660,10 +660,42 @@ logsCollector:
         pod_association:
           - sources:
               - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: resource_attribute
                 name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+              - from: resource_attribute
+                name: k8s.node.name
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+          - sources:
+              - from: connection
         extract:
+          labels:
+            - tag_name: service.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: service.name
+              key: k8s-app
+              from: pod
+            - tag_name: k8s.app.instance
+              key: app.kubernetes.io/instance
+              from: pod
+            - tag_name: service.version
+              key: app.kubernetes.io/version
+              from: pod
+            - tag_name: k8s.app.component
+              key: app.kubernetes.io/component
+              from: pod
           metadata:
-            - k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.pod.uid
@@ -676,11 +708,13 @@ logsCollector:
             - k8s.daemonset.uid
             - k8s.job.name
             - k8s.job.uid
+            - k8s.container.name
             - k8s.cronjob.name
             - k8s.statefulset.name
             - k8s.statefulset.uid
             - container.image.tag
             - container.image.name
+            - k8s.cluster.uid
 
     exporters:
       otlp:


### PR DESCRIPTION
What does this PR do?
---------------------

Adds the same k8sattribute processor configuration to the logsCollector as the other collector configurations

For what purpose?
---------------------

This k8sattribute processor attaches some important attributes like `service.name` as well as our common slate of kubernetes resource attributes to log messages collected via the logsCollector

How did you test this?
---------------------

Made the change to the helm chart locally, then applied to the demo environment that uses otel-cloud-stack. Saw service.name, service.version, and other attributes populate for the logs coming from the demo environment