### PR TITLE
Initial commit - GHA workflow for building image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,46 @@
+#
+name: Create and publish a Docker image for Otel Collectors with Arrow
+
+on:
+  workflow_dispatch:
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/otelarrowcol
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+        #   tags: ${{ steps.meta.outputs.tags }}
+        #   labels: ${{ steps.meta.outputs.labels }}

--- a/arrow/Dockerfile
+++ b/arrow/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.21 AS sandbox
+
+WORKDIR /otelarrowcol
+COPY . .
+ENV CGO_ENABLED=0
+
+# Note the version MUST MATCH otelarrowcol-build.yaml
+# Future optimization - curl the release.
+RUN go install go.opentelemetry.io/collector/cmd/builder@v0.89.0
+
+# This command generates main.go, go.mod but does not update deps.
+RUN builder --config=/otelarrowcol/otelcolarrow-build.yaml
+
+# This build uses an Alpine Linux container.
+FROM alpine AS release
+COPY --from=sandbox /otelarrowcol/dist/otelarrowcol /otelarrowcol
+
+# Network ports
+# 4317 - OpenTelemetry gRPC services:
+#      - OpenTelemetry Protocol with Apache Arrow
+#      - OpenTelemetry Protocol (OTLP)
+# 1777 - Profiling support
+EXPOSE 4317/tcp 1777/tcp
+
+ENTRYPOINT ["/otelarrowcol"]

--- a/arrow/Makefile
+++ b/arrow/Makefile
@@ -1,0 +1,11 @@
+build-amd64:
+	docker build . -t otelarrowcol-amd64 --platform linux/amd64
+
+build-arm64:
+	docker build . -t otelarrowcol-arm64 --platform linux/arm64
+
+run-amd64:
+	docker run -it -v ./config/:/config --entrypoint /otelarrowcol otelarrowcol-amd64 --config=/config/saas-collector.yaml
+
+run-arm64:
+	docker run -it -v ./config/:/config --entrypoint /otelarrowcol otelarrowcol-arm64 --config=/config/saas-collector.yaml

--- a/arrow/config/saas-collector.yaml
+++ b/arrow/config/saas-collector.yaml
@@ -1,0 +1,60 @@
+receivers:
+  # otelarrow is an OTel Arrow receiver that will operate as the SaaS-side
+  # of the bridge.
+  otelarrow:
+    protocols:
+      grpc:
+        # Port 5000 is the endpoint used in edge-collector.
+        endpoint: 127.0.0.1:8100
+
+        # Include metadata so that the exporter can copy it
+        # to the next hop.
+        include_metadata: true
+
+        keepalive:
+          server_parameters:
+            max_connection_age: 10s
+            max_connection_age_grace: 10s
+
+exporters:
+  debug:      
+
+  otlphttp:
+    # You can use an HTTP listener on port 5001 to see the headers
+    # and raw data.
+    endpoint: http://127.0.0.1:8101
+    compression: none
+
+    # Associate the headers_setter extension with this exporter
+    # so that it passes through headers set on the edge collector.
+    auth:
+      authenticator: headers_setter
+
+extensions:
+  # Configure the headers_setter extension to propagate the
+  # X-Scope-OrgID property in the outgoing context.
+  headers_setter:
+    headers:
+      - key: X-Scope-OrgID
+        from_context: X-Scope-OrgID
+
+service:
+  extensions: [headers_setter]
+  pipelines:
+    traces:
+      receivers: [otelarrow]
+
+      # Note there is no need to re-apply the batch processor on the
+      # SaaS-side of a bridge.
+      processors: []
+      exporters: [debug, otlphttp]
+
+    metrics:
+      receivers: [otelarrow]
+      processors: []
+      exporters: [debug, otlphttp]
+      
+  telemetry:
+    metrics:
+      address: 127.0.0.1:8889
+      level: normal

--- a/arrow/otelcolarrow-build.yaml
+++ b/arrow/otelcolarrow-build.yaml
@@ -1,0 +1,47 @@
+# This file describes a sample OpenTelemetry Collector build
+# containing the primary OpenTelemetry Protocol with Apache Arrow
+# components and a few generally useful components from the
+# OpenTelemetry Collector Contrib repository that have proven useful.
+#
+# The full list of components is detailed below.  Many of these
+# components are optional and meant to assist with experimentation
+# and validation of the primary components.
+#
+# This configuration file be used as a starting point for building a
+# custom gateway collector for deploying OpenTelemetry Protocol with
+# Apache Arrow in production.  See the instructions in BUILDING.md.
+dist:
+  module: github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol
+  # Project-internal use: Directory path required for the `make
+  # genotelarrowcol`, which the Dockerfile also recognizes.
+  #
+  # Users: This can be customized for integration into your CI/CD system.
+  output_path: dist/
+  name: otelarrowcol
+  
+  description: OpenTelemetry Protocol with Apache Arrow development collector, for testing and evaluation
+
+  # Note: this version number is replaced to match the current release using `sed`
+  # during the release process, see ../../../RELEASING.md.
+  version: 0.10.0
+
+  # Note: This should match the version of the core and contrib
+  # collector components used below (e.g., the debugexporter and
+  # otlphttpexporter versions below).
+  otelcol_version: 0.89.0
+
+exporters:
+  # This is the core OpenTelemetry Protocol with Apache Arrow exporter
+  - import: github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter
+    gomod: github.com/open-telemetry/otel-arrow/collector v0.10.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.89.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.89.0
+
+receivers:
+  # This is the core OpenTelemetry Protocol with Apache Arrow receiver
+  - import: github.com/open-telemetry/otel-arrow/collector/receiver/otelarrowreceiver
+    gomod: github.com/open-telemetry/otel-arrow/collector v0.10.0
+
+
+extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.88.0


### PR DESCRIPTION
# What does this PR do?
* Enables this repo to create readymade docker images of OTel Collector using Arrow for easier consumption.

# How?
* The GHA will run the workflow when manually triggered.

This probably only needs to happen when an arrow release occurs.