### PR TITLE
Fix GHA workflow building docker image, incl tag and label

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -42,5 +42,5 @@ jobs:
         with:
           context: .
           push: true
-        #   tags: ${{ steps.meta.outputs.tags }}
-        #   labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixes: https://github.com/lightstep/otel-collector-charts/pull/57 which broke in: https://github.com/lightstep/otel-collector-charts/actions/runs/6963417217/job/18948958809 because there was no tag or label.

