### PR TITLE
Get/set docker image tag for otelcolarrow from build config

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -17,7 +17,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,6 +27,12 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read build config YAML and read/set otelcol version
+        id: read-yaml
+        run: |
+          # Parse the YAML file and extract the otelcol version
+          OTELCOL_VERSION=$(yq -r '.dist.otelcol_version' otelcolarrow-build.yaml)
+          echo "OTELCOL_VERSION=${OTELCOL_VERSION}" >> $GITHUB_ENV
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -35,6 +40,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-EXPERIMENTAL
           tags: |
+            # Set the OTELCOL_VERSION here
+            echo "::set-output name=otelcol-version-tag::${OTELCOL_VERSION}"
             # set latest tag for master branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.


### PR DESCRIPTION
Description
---------------------
* Sets the `OTELCOL_VERSION` as the docker image tag. 


How Has This Been Tested?
---------------------
Nil


Please describe how you tested your changes. When applicable, provide instructions on how the reviewer can also test your changes.

***
R/CC: _Who should know about this change? Requesting any reviewers in particular?_
