### PR TITLE
Support amd and arm platforms for otelcol-arrow docker image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/otelarrowcol
+  PLATFORMS: linux/amd64,linux/arm64
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
@@ -43,6 +44,15 @@ jobs:
             type=raw,value=${{ steps.read-yaml.outputs.otelcol_version }}
             # set latest tag for master branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
@@ -52,5 +62,9 @@ jobs:
           context: ./arrow
           # Only push to GHCR if this change is off the main branch
           push: ${{ github.ref == format('refs/heads/{0}', 'main') }}
+          # Build for all platforms specified.
+          platforms: ${{ env.PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Description
---------------------
* Support AMD and ARM platforms for the otelcol-arrow image.
* Based off what was done for the `otel-op`: https://github.com/open-telemetry/opentelemetry-operator/blob/main/.github/workflows/publish-images.yaml

How Has This Been Tested?
---------------------

Please describe how you tested your changes. When applicable, provide instructions on how the reviewer can also test your changes.

***
R/CC: _Who should know about this change? Requesting any reviewers in particular?_
