### PR TITLE
Update readme to include references to ghcr.io/lightstep/otel-collector-charts/otelcolarrow-experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,19 @@ This is the repository for recommended [Helm](https://helm.sh/) charts for runni
 > [!NOTE] 
 > Arrow usage is in beta, please use at your own risk. Reach out if you have any issues.
 
-In order to use an arrow trace collector, you will need to build your own custom image. We have supplied a collector builder config below. Once an image is a available, simply apply your desired helm chart with the values.yaml AND the arrow.yaml in the respective chart. Make sure to replace the image in arrow.yaml with your custom built image.
+In order to use an arrow trace collector, you can use  (1) the prebuilt image available via the Github Container Registry (GHCR) or you may (2) build your own custom image.
+
+### 1. Use the prebuilt Docker image
+1. We have built a Docker image using the example [build config](https://github.com/lightstep/otel-collector-charts/blob/main/arrow/otelcolarrow-build.yaml)
+2. This Docker [image](https://github.com/lightstep/otel-collector-charts/pkgs/container/otel-collector-charts%2Fotelarrowcol-experimental) can be pulled by running: `docker pull ghcr.io/lightstep/otel-collector-charts/otelarrowcol-experimental:latest`
+3. You can use the example collector config (`/arrow/config/saas-config.yaml`) by running:
+`docker run -it -v ./config/:/config --entrypoint /otelarrowcol ghcr.io/lightstep/otel-collector-charts/otelarrowcol-experimental:latest --config=/config/saas-collector.yaml`
+
+
+### 2. Build your own custom image
+1.  We have supplied a collector builder config below. 
+2. Once an image is a available, simply apply your desired helm chart with the values.yaml AND the arrow.yaml in the respective chart. 
+3. Make sure to replace the image in arrow.yaml with your custom built image.
 
 ## Build configurations
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In order to use an arrow trace collector, you can use  (1) the prebuilt image av
 
 
 ### 2. Build your own custom image
-1.  We have supplied a collector builder config below. 
+1. We have supplied a collector builder config below. 
 2. Once an image is a available, simply apply your desired helm chart with the values.yaml AND the arrow.yaml in the respective chart. 
 3. Make sure to replace the image in arrow.yaml with your custom built image.
 

--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: 0.83.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/arrow.yaml
+++ b/charts/kube-otel-stack/arrow.yaml
@@ -4,7 +4,7 @@
 # does not include these components yet, so a custom image will be
 # needed.  See https://github.com/lightstep/otel-collector-charts/blob/main/gateway-build.yaml
 tracesCollector:
-  image: "your-image-with-arrow-here"
+  image: "ghcr.io/lightstep/otel-collector-charts/otelarrowcol-experimental:latest"
   resources:
     # OTel-Arrow notes: to use OTel-Arrow in a gateway configuration,
     # we recommend the following adjustments:

--- a/charts/otel-cloud-stack/Chart.yaml
+++ b/charts/otel-cloud-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.2.8"
+version: "0.2.9"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/otel-cloud-stack/arrow.yaml
+++ b/charts/otel-cloud-stack/arrow.yaml
@@ -4,7 +4,7 @@
 # does not include these components yet, so a custom image will be
 # needed.  See https://github.com/lightstep/otel-collector-charts/blob/main/gateway-build.yaml
 tracesCollector:
-  image: "your-image-with-arrow-here"
+  image: "ghcr.io/lightstep/otel-collector-charts/otelarrowcol-experimental:latest"
   resources:
     # OTel-Arrow notes: to use OTel-Arrow in a gateway configuration,
     # we recommend the following adjustments:


### PR DESCRIPTION
Description
---------------------

* Update readme with references to the `otelcolarrow-example` prebuilt docker image on GHCR.
* Note packages can be examined here: https://github.com/orgs/lightstep/packages?tab=packages&q=otel
   * i.e. this specific one: https://github.com/orgs/lightstep/packages?tab=packages&q=otel 

How Has This Been Tested?
---------------------
* GHA workflow runs as expected: https://github.com/lightstep/otel-collector-charts/actions/runs/7024362460
* Confirmed able to pull the docker image
```
docker pull ghcr.io/lightstep/otel-collector-charts/otelarrowcol-experimental:latest
latest: Pulling from lightstep/otel-collector-charts/otelarrowcol-experimental
96526aa774ef: Pull complete
58f05ea3c670: Pull complete
Digest: sha256:66f2ec4ddf9b9d2e196f3bf89d1fadf38c0ce4b5008e1929964cbd00ed81ab1d
Status: Downloaded newer image for ghcr.io/lightstep/otel-collector-charts/otelarrowcol-experimental:latest
ghcr.io/lightstep/otel-collector-charts/otelarrowcol-experimental:latest
```
* Confirmed able to run the docker image

```
❯ ls                                                                                           15:20:30
LICENSE            arrow              ct.yaml
README.md          charts             gateway-build.yaml
❯ cd arrow                                                                                     15:20:31
❯ ls                                                                                     15:20:32
Dockerfile              Makefile                config                  otelcolarrow-build.yaml
❯ docker run -it -v ./config/:/config --entrypoint /otelarrowcol ghcr.io/lightstep/otel-collector-charts/otelarrowcol-experimental:latest --config=/config/saas-collector.yaml
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
2023-11-28T23:21:12.925Z	info	service@v0.89.0/telemetry.go:85	Setting up own telemetry...
2023-11-28T23:21:12.935Z	info	service@v0.89.0/telemetry.go:202	Serving Prometheus metrics	{"address": "127.0.0.1:8889", "level": "Normal"}
2023-11-28T23:21:12.937Z	warn	headerssetterextension@v0.88.0/extension.go:55	The action was not provided, using 'upsert'. In future versions, we'll require this to be explicitly set	{"kind": "extension", "name": "headers_setter"}
2023-11-28T23:21:12.952Z	info	exporter@v0.89.0/exporter.go:275	Development component. May change in the future.	{"kind": "exporter", "data_type": "traces", "name": "debug"}
2023-11-28T23:21:12.955Z	info	exporter@v0.89.0/exporter.go:275	Development component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "debug"}
2023-11-28T23:21:12.963Z	info	service@v0.89.0/service.go:143	Starting otelarrowcol...	{"Version": "0.10.0", "NumCPU": 5}
2023-11-28T23:21:12.963Z	info	extensions/extensions.go:34	Starting extensions...
2023-11-28T23:21:12.963Z	info	extensions/extensions.go:37	Extension is starting...	{"kind": "extension", "name": "headers_setter"}
2023-11-28T23:21:12.964Z	info	extensions/extensions.go:45	Extension started.	{"kind": "extension", "name": "headers_setter"}
2023-11-28T23:21:12.970Z	info	otelarrowreceiver@v0.10.0/otlp.go:98	Starting GRPC server	{"kind": "receiver", "name": "otelarrow", "data_type": "traces", "endpoint": "127.0.0.1:8100"}
2023-11-28T23:21:12.972Z	info	service@v0.89.0/service.go:169	Everything is ready. Begin running and processing data.
^C2023-11-28T23:21:20.810Z	info	otelcol@v0.89.0/collector.go:258	Received signal from OS{"signal": "interrupt"}
2023-11-28T23:21:20.811Z	info	service@v0.89.0/service.go:178	Starting shutdown...
2023-11-28T23:21:20.831Z	info	extensions/extensions.go:52	Stopping extensions...
2023-11-28T23:21:20.832Z	info	service@v0.89.0/service.go:192	Shutdown complete.
```

***
R/CC: _Who should know about this change? Requesting any reviewers in particular?_
