### PR TITLE
Fix typo with collector build file path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ OpenTelemetry Protocol With Apache Arrow support requires using either
 the prebuilt image or a customer collector build at this time.
 
 See the [recommended custom collector build
-configuration](./arrow/otelcolarrow-build.yaml.yaml) as a starting
+configuration](./arrow/otelcolarrow-build.yaml) as a starting
 point.


### PR DESCRIPTION
Description
---------------------
Fixes a typo for the path to the collector build file

How Has This Been Tested?
---------------------

You can see the correct file here: https://github.com/lightstep/otel-collector-charts/blob/main/arrow/otelcolarrow-build.yaml

***
R/CC: @jmacd 
