### PR TITLE
feat: Adding instrumentation specific settings and adjust whitespacing

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.91.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/templates/autoinstrumentation.yaml
+++ b/charts/kube-otel-stack/templates/autoinstrumentation.yaml
@@ -6,28 +6,32 @@ metadata:
 spec:
   exporter:
     endpoint: http://{{ $.Release.Name }}-{{ .Values.autoinstrumentation.collectorTarget }}-collector.{{ $.Release.Namespace }}:4317
-  propagators: {{ toYaml .Values.autoinstrumentation.propagators | nindent 4 }}
+  propagators:
+{{ toYaml .Values.autoinstrumentation.propagators | indent 4 }}
   {{- with .Values.autoinstrumentation.sampler }}
-  sampler: {{ toYaml . | nindent 4 }}
+  sampler:
+{{ toYaml . | indent 4 }}
   {{- end }}
   {{- with .Values.autoinstrumentation.env }}
-  env: {{ toYaml . | nindent 4 }}
+  env:
+{{ toYaml . | indent 4 }}
   {{- end }}
   {{- with .Values.autoinstrumentation.resource }}
-  resource: {{ toYaml . | nindent 4 }}
+  resource:
+{{ toYaml . | indent 4 }}
   {{- end }}
   {{- range $language, $settings := .Values.autoinstrumentation.languagesettings }}
-    {{- with $settings }}
   {{$language}}:
-    {{- with .env }}
-    env: {{ toYaml . | nindent 6 }}
+    {{- with $settings.env }}
+    env:
+{{ toYaml . | indent 6 }}
     {{- end }}
-    {{- if .image }}
-    image: {{ .image | quote }}
+    {{- if $settings.image }}
+    image: {{ $settings.image | quote }}
     {{- end }}
-    {{- with .resources }}
-    resources: {{ toYaml . | nindent 6 }}
-    {{- end }}
+    {{- with $settings.resources }}
+    resources:
+{{ toYaml . | indent 6 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kube-otel-stack/templates/autoinstrumentation.yaml
+++ b/charts/kube-otel-stack/templates/autoinstrumentation.yaml
@@ -21,7 +21,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- range $language, $settings := .Values.autoinstrumentation.languageSettings }}
-  {{$language}}:
+  {{ $language }}:
     {{- with $settings.env }}
     env:
       {{- toYaml . | nindent 6 }}

--- a/charts/kube-otel-stack/templates/autoinstrumentation.yaml
+++ b/charts/kube-otel-stack/templates/autoinstrumentation.yaml
@@ -20,7 +20,7 @@ spec:
   resource:
 {{ toYaml . | indent 4 }}
   {{- end }}
-  {{- range $language, $settings := .Values.autoinstrumentation.languagesettings }}
+  {{- range $language, $settings := .Values.autoinstrumentation.languageSettings }}
   {{$language}}:
     {{- with $settings.env }}
     env:

--- a/charts/kube-otel-stack/templates/autoinstrumentation.yaml
+++ b/charts/kube-otel-stack/templates/autoinstrumentation.yaml
@@ -7,31 +7,31 @@ spec:
   exporter:
     endpoint: http://{{ $.Release.Name }}-{{ .Values.autoinstrumentation.collectorTarget }}-collector.{{ $.Release.Namespace }}:4317
   propagators:
-{{ toYaml .Values.autoinstrumentation.propagators | indent 4 }}
+    {{- toYaml .Values.autoinstrumentation.propagators | nindent 4 }}
   {{- with .Values.autoinstrumentation.sampler }}
   sampler:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.autoinstrumentation.env }}
   env:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.autoinstrumentation.resource }}
   resource:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- range $language, $settings := .Values.autoinstrumentation.languageSettings }}
   {{$language}}:
     {{- with $settings.env }}
     env:
-{{ toYaml . | indent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- if $settings.image }}
     image: {{ $settings.image | quote }}
     {{- end }}
     {{- with $settings.resources }}
     resources:
-{{ toYaml . | indent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kube-otel-stack/templates/autoinstrumentation.yaml
+++ b/charts/kube-otel-stack/templates/autoinstrumentation.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.autoinstrumentation.enabled }}
+{{- if .Values.autoinstrumentation.enabled }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
@@ -6,18 +6,28 @@ metadata:
 spec:
   exporter:
     endpoint: http://{{ $.Release.Name }}-{{ .Values.autoinstrumentation.collectorTarget }}-collector.{{ $.Release.Namespace }}:4317
-  propagators:
-{{ toYaml .Values.autoinstrumentation.propagators | indent 4 }}
-  {{ with .Values.autoinstrumentation.sampler }}
-  sampler:
-{{ toYaml . | indent 4 }}
-  {{ end }}
-  {{ with .Values.autoinstrumentation.env }}
-  env:
-{{ toYaml . | indent 4 }}
-  {{ end }}
-  {{ with .Values.autoinstrumentation.resource }}
-  resource:
-{{ toYaml . | indent 4 }}
-  {{ end }}
+  propagators: {{ toYaml .Values.autoinstrumentation.propagators | nindent 4 }}
+  {{- with .Values.autoinstrumentation.sampler }}
+  sampler: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.autoinstrumentation.env }}
+  env: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.autoinstrumentation.resource }}
+  resource: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- range $language, $settings := .Values.autoinstrumentation.languagesettings }}
+    {{- with $settings }}
+  {{$language}}:
+    {{- with .env }}
+    env: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if .image }}
+    image: {{ .image | quote }}
+    {{- end }}
+    {{- with .resources }}
+    resources: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -32,7 +32,16 @@ autoinstrumentation:
     ## The value depends on the sampler type.
     ## For instance for parentbased_traceidratio sampler type it is a number in range [0..1] e.g. 0.25.
     argument: "0.25"
-
+  languagesettings: {}
+  # Languagesettings defines the language specific settings for auto-instrumentation. Example:
+    # python:
+    #   env:
+    #     - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+    #       value: 'true'
+    #     - name: OTEL_TRACES_EXPORTER
+    #       value: otlp
+    #   image: "<custom-image>"
+    #   resources: {}
   ## A list of corev1.EnvVars
   env: []
 

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -37,9 +37,9 @@ autoinstrumentation:
     # python:
     #   env:
     #     - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
-    #       value: 'true'
+    #       value: "true"
     #     - name: OTEL_TRACES_EXPORTER
-    #       value: otlp
+    #       value: "otlp"
     #   image: "<custom-image>"
     #   resources: {}
   ## A list of corev1.EnvVars

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -32,8 +32,8 @@ autoinstrumentation:
     ## The value depends on the sampler type.
     ## For instance for parentbased_traceidratio sampler type it is a number in range [0..1] e.g. 0.25.
     argument: "0.25"
-  languagesettings: {}
-  # Languagesettings defines the language specific settings for auto-instrumentation. Example:
+  languageSettings: {}
+  # LanguageSettings defines the language specific settings for auto-instrumentation. Example:
     # python:
     #   env:
     #     - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED


### PR DESCRIPTION

Description
---------------------

I want to be able to add auto-instrumentation specific things and not see giant whitespaces when running helm template

How Has This Been Tested?
---------------------

Running helm template and then applying this on my environment

sample helm template
```
apiVersion: opentelemetry.io/v1alpha1
kind: Instrumentation
metadata:
  name: kube-otel-stack-instrumentation
spec:
  exporter:
    endpoint: http://kube-otel-stack-traces-collector.default:4317
  propagators:
    - tracecontext
    - baggage
    - b3
  sampler:
    argument: "0.25"
    type: parentbased_traceidratio
  env:
    - name: OTEL_LOG_LEVEL
      value: DEBUG
    - name: OTEL_EXPORTER_OTLP_ENDPOINT
      value: traces:4317
  python:
    env:
      - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
        value: "true"
      - name: OTEL_TRACES_EXPORTER
        value: otlp
```

***
R/CC: _Who should know about this change? Requesting any reviewers in particular?_
