### PR TITLE
Fix monitoring of collector when in daemonset mode

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.91.0
 dependencies:
 # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -105,16 +105,16 @@ spec:
             scrape_interval: 5s
             static_configs:
             - labels:
-                collector_name: ${KUBE_POD_NAME}
+                collector_name: ${OTEL_K8S_POD_NAME}
               targets:
-                - 0.0.0.0:8888
+                - ${OTEL_K8S_POD_IP}:8888
           {{ end }}
         {{- if $collector.targetallocator }}
         {{- if $collector.targetallocator.enabled }}
         target_allocator:
           endpoint: http://{{ $collectorName }}-targetallocator:80
           interval: 30s
-          collector_id: ${POD_NAME}
+          collector_id: ${OTEL_K8S_POD_NAME}
           http_sd_config:
             refresh_interval: 60s
         {{ end }}

--- a/charts/kube-otel-stack/templates/servicemonitors.yaml
+++ b/charts/kube-otel-stack/templates/servicemonitors.yaml
@@ -1,4 +1,4 @@
-{{ $collectorList := (append (append .Values.collectors .Values.tracesCollector) .Values.metricsCollector) }}
+{{ $collectorList := (append (append (append .Values.collectors .Values.tracesCollector) .Values.metricsCollector) .Values.logsCollector)}}
 {{ range $_, $collector := $collectorList -}}
 {{ if $collector.enabled }}
 {{ $collectorName := (print $.Release.Name "-" $collector.name) }}


### PR DESCRIPTION
Description
---------------------

- Fixed monitoring of collector when in daemonset mode. This was broken when environment variables were renamed in b6354b1f003776504761a76b55240b282b0a6dd6
- Use OTEL_K8S_POD_IP in `otel-collector` job so that instance label can be unique.

How Has This Been Tested?
---------------------

Please describe how you tested your changes. When applicable, provide instructions on how the reviewer can also test your changes.

***
R/CC: _Who should know about this change? Requesting any reviewers in particular?_
