### PR TITLE
Make it possible to override OTLP destination

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.91.0
 dependencies:
-# cert manager must be manually installed because it has CRDs
-# https://github.com/kubernetes-sigs/security-profiles-operator/issues/1062
-# - name: opentelemetry-operator
-#   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-#   version: 0.15.0
-- name: kube-state-metrics
-  version: "4.20.2"
-  repository: "https://prometheus-community.github.io/helm-charts"
-  condition: kubeStateMetrics.enabled
-- name: prometheus-node-exporter
-  version: "4.3.0"
-  repository: "https://prometheus-community.github.io/helm-charts"
-  condition: nodeExporter.enabled
+  # cert manager must be manually installed because it has CRDs
+  # https://github.com/kubernetes-sigs/security-profiles-operator/issues/1062
+  # - name: opentelemetry-operator
+  #   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  #   version: 0.15.0
+  - name: kube-state-metrics
+    version: "4.20.2"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: kubeStateMetrics.enabled
+  - name: prometheus-node-exporter
+    version: "4.3.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: nodeExporter.enabled

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -94,6 +94,11 @@ spec:
       value: "k8s.cluster.name={{ $collector.clusterName | default $.Values.clusterName }}"
   config: |
     exporters:
+      {{- if $.Values.otlpDestinationOverride }}
+      {{- if (dig "exporters" "otlp" "endpoint" false $collector.config) }}
+      {{- $_ := set $collector.config.exporters.otlp "endpoint" $.Values.otlpDestinationOverride }}
+      {{- end }}
+      {{- end }}
       {{- toYaml $collector.config.exporters | nindent 6 }}
     extensions:
       {{- toYaml $collector.config.extensions | nindent 6 }}

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -3,6 +3,7 @@ namespaceOverride: ""
 nameOverride: ""
 operatorNamespaceOverride: ""
 clusterName: "unknown"
+otlpDestinationOverride: ""
 
 ## Auto-Instrumentation resource to be installed in the cluster
 ## Can be used by setting the following:
@@ -34,14 +35,14 @@ autoinstrumentation:
     argument: "0.25"
   languageSettings: {}
   # LanguageSettings defines the language specific settings for auto-instrumentation. Example:
-    # python:
-    #   env:
-    #     - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
-    #       value: "true"
-    #     - name: OTEL_TRACES_EXPORTER
-    #       value: "otlp"
-    #   image: "<custom-image>"
-    #   resources: {}
+  # python:
+  #   env:
+  #     - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+  #       value: "true"
+  #     - name: OTEL_TRACES_EXPORTER
+  #       value: "otlp"
+  #   image: "<custom-image>"
+  #   resources: {}
   ## A list of corev1.EnvVars
   env: []
 
@@ -58,7 +59,7 @@ tracesCollector:
   name: traces
   clusterName: ""
 
-  image: otel/opentelemetry-collector-contrib:0.88.0
+  image: otel/opentelemetry-collector-contrib:0.96.0
   mode: deployment
   replicas: 1
   hpa:
@@ -219,7 +220,7 @@ tracesCollector:
 metricsCollector:
   name: metrics
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.88.0
+  image: otel/opentelemetry-collector-contrib:0.96.0
   enabled: true
   mode: statefulset
   replicas: 3
@@ -232,7 +233,7 @@ metricsCollector:
     enabled: true
     allocationStrategy: "consistent-hashing"
     replicas: 2
-    image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.88.0
+    image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.96.0
     prometheusCR:
       enabled: true
     # Override Default targetAllocator resources
@@ -347,7 +348,7 @@ metricsCollector:
 logsCollector:
   name: logs
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.88.0
+  image: otel/opentelemetry-collector-contrib:0.96.0
   enabled: false
   mode: daemonset
   resources:

--- a/charts/otel-cloud-stack/Chart.yaml
+++ b/charts/otel-cloud-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.4.0"
+version: "0.4.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/otel-cloud-stack/templates/collector.yaml
+++ b/charts/otel-cloud-stack/templates/collector.yaml
@@ -129,6 +129,11 @@ spec:
       {{- end }}
   config: |
     exporters:
+      {{- if $.Values.otlpDestinationOverride }}
+      {{- if (dig "exporters" "otlp" "endpoint" false $collector.config) }}
+      {{- $_ := set $collector.config.exporters.otlp "endpoint" $.Values.otlpDestinationOverride }}
+      {{- end }}
+      {{- end }}
       {{- toYaml $collector.config.exporters | nindent 6 }}
     receivers:
       {{- if $collector.scrape_configs_file }}

--- a/charts/otel-cloud-stack/values.yaml
+++ b/charts/otel-cloud-stack/values.yaml
@@ -1,6 +1,7 @@
 extraEnvs: []
 debug: false
 clusterName: "unknown"
+otlpDestinationOverride: ""
 
 ## Auto-Instrumentation resource to be installed in the cluster
 ## Can be used by setting the following:
@@ -40,7 +41,7 @@ autoinstrumentation:
 daemonCollector:
   name: daemon
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.88.0
+  image: otel/opentelemetry-collector-contrib:0.96.0
   enabled: true
   mode: daemonset
   mountHostFS: true
@@ -304,7 +305,7 @@ daemonCollector:
 clusterCollector:
   name: cluster-stats
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.88.0
+  image: otel/opentelemetry-collector-contrib:0.96.0
   replicas: 1
   mode: deployment
   enabled: true
@@ -425,7 +426,7 @@ tracesCollector:
   enabled: false
   name: traces
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.88.0
+  image: otel/opentelemetry-collector-contrib:0.96.0
   mode: deployment
   hpa:
     minReplicas: 1
@@ -541,7 +542,7 @@ logsCollector:
   enabled: false
   name: logs
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.88.0
+  image: otel/opentelemetry-collector-contrib:0.96.0
   mode: daemonset
   resources:
     limits:


### PR DESCRIPTION
Description
---------------------
Upgrade the default versions to 0.96.0 also make it possible to override the OTLP destination for all otlp exporters.


How Has This Been Tested?
---------------------
ran helm template locally to verify that the otlp override worked.

***
R/CC: @smithclay @robswhitmore 
