### PR TITLE
Enable OpAMP Bridge by default

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.5.1
+version: 0.6.0
 appVersion: 0.91.0
 dependencies:
   # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -1245,7 +1245,7 @@ prometheus-node-exporter:
     pspEnabled: false
 
 opAMPBridge:
-  enabled: false
+  enabled: true
   # Adds `opentelemetry.io/opamp-reporting: true` to all collectors
   addReportingLabel: true
   # Adds `opentelemetry.io/opamp-managed: true` to all collectors

--- a/charts/otel-cloud-stack/Chart.yaml
+++ b/charts/otel-cloud-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.4.1"
+version: "0.5.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/otel-cloud-stack/values.yaml
+++ b/charts/otel-cloud-stack/values.yaml
@@ -740,7 +740,7 @@ logsCollector:
 collectors: []
 
 opAMPBridge:
-  enabled: false
+  enabled: true
   # Adds `opentelemetry.io/opamp-reporting: true` to all collectors
   addReportingLabel: true
   # Adds `opentelemetry.io/opamp-managed: true` to all collectors


### PR DESCRIPTION
Description
---------------------

* For both _otel-cloud-stack_ and _kube-otel-stack_ charts, switched `opAMPBridge.enabled` to `true` so that the OpAMP bridge is provisioned by default during Helm chart install
* Incremented minor version of both charts to reflect the change in behavior

For Docs team
---------------------

This help simplify updated quick start product docs about that include opamp for monitoring. With this change, the OpAMP Bridge will be enabled by default for customers, so no special instruction are needed in quick start guides and docs about enabling the bridge. However, with the bridge enabled by default, we will need to make sure we direct customers to generate and save an API Key (as a kubernetes secret) for the bridge

It also might be important to recognize that this behavior is introduced with these new chart versions (from this PR)

* _otel-cloud-stack_: `0.5.0`
* _kube-otel-stack_: `0.6.0`

How did you test this?
---------------------

Ran the following commands before and after changes to render k8s configs:
```
helm template otel-cloud-stack otel-cloud-stack -f otel-cloud-stack/values.yaml --set clusterName='gfast-test' --set=tracesCollector.enabled=true --set=logsCollector.enabled=true

helm template kube-otel-stack kube-otel-stack -f kube-otel-stack/values.yaml --set clusterName='gfast-test' --set=tracesCollector.enabled=true --set=logsCollector.enabled=true

```
I then `diff`ed the old and new configs for each chart. I checked each diff to ensure that we saw the following changes (and nothing more), and all looked good

1. Chart version updates
2. Collectors now get the `opentelemetry.io/opamp-reporting: "true"` label
3. Configs for new resources: bridge `ClusterRole`, bridge `ClusterRoleBinding`, `OpAMPBridge`

[kube_otel_stack_new.yaml.txt](https://github.com/lightstep/otel-collector-charts/files/14827118/kube_otel_stack_new.yaml.txt)
[kube_otel_stack_orig.yaml.txt](https://github.com/lightstep/otel-collector-charts/files/14827119/kube_otel_stack_orig.yaml.txt)
[kube_otel_stack_diff.txt](https://github.com/lightstep/otel-collector-charts/files/14827117/kube_otel_stack_diff.txt)

[otel_cloud_stack_new.yaml.txt](https://github.com/lightstep/otel-collector-charts/files/14827121/otel_cloud_stack_new.yaml.txt)
[otel_cloud_stack_orig.yaml.txt](https://github.com/lightstep/otel-collector-charts/files/14827122/otel_cloud_stack_orig.yaml.txt)
[otel_cloud_stack_diff.txt](https://github.com/lightstep/otel-collector-charts/files/14827120/otel_cloud_stack_diff.txt)