### PR TITLE
Mark opamp secret as optional in charts

### DIFF
--- a/charts/kube-otel-stack/Chart.yaml
+++ b/charts/kube-otel-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-otel-stack
 description: Chart for sending Kubernetes metrics to Lightstep using the OpenTelemetry Operator.
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.91.0
 dependencies:
   # cert manager must be manually installed because it has CRDs

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -1262,6 +1262,7 @@ opAMPBridge:
         secretKeyRef:
           key: LS_OPAMP_API_KEY
           name: otel-opamp-bridge-secret
+          optional: true
   capabilities:
     AcceptsOpAMPConnectionSettings: true
     AcceptsOtherConnectionSettings: true

--- a/charts/otel-cloud-stack/Chart.yaml
+++ b/charts/otel-cloud-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.5.0"
+version: "0.5.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/otel-cloud-stack/values.yaml
+++ b/charts/otel-cloud-stack/values.yaml
@@ -757,6 +757,7 @@ opAMPBridge:
         secretKeyRef:
           key: LS_OPAMP_API_KEY
           name: otel-opamp-bridge-secret
+          optional: true
   capabilities:
     AcceptsOpAMPConnectionSettings: true
     AcceptsOtherConnectionSettings: true


### PR DESCRIPTION
Description
---------------------

Marks `LS_OPAMP_API_KEY` as optional so they container will not crash if the secret is not set (the env var will just be empty).

***
R/CC: @jdcrouse 
