### PR TITLE
Updated to image repository to download using ghcr.io instead of docker.io

### DIFF
--- a/charts/collector-k8s/templates/collector.yaml
+++ b/charts/collector-k8s/templates/collector.yaml
@@ -7,7 +7,7 @@ metadata:
   name: "{{ $collectorName }}"
 spec:
   mode: {{ $collector.mode }}
-  image: {{ $collector.image }}
+  image: "{{ $collector.image.repository }}:{{ $collector.image.tag | default $.Chart.AppVersion }}"
   replicas: {{ $collector.replicas | default 1 }}
   ports:
     - name: "metrics"
@@ -16,7 +16,7 @@ spec:
 {{- if eq $collector.mode "statefulset" }}
   targetAllocator:
     enabled: true
-    image: {{ $collector.targetallocator.image }}
+    image: "{{ $collector.targetallocator.image.repository }}:{{ $collector.targetallocator.image.tag | default $.Chart.AppVersion }}"
     serviceAccount: {{ $.Release.Name }}-collector-targetallocator
     prometheusCR:
       enabled: {{ $collector.targetallocator.prometheusCR.enabled }}

--- a/charts/collector-k8s/values-daemonset.yaml
+++ b/charts/collector-k8s/values-daemonset.yaml
@@ -2,7 +2,9 @@ collectors:
   # The deployment collector should be configured to scrape infrastructure or static targets.
   - name: deployment
     enabled: false
-    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.58.0
+    image:
+      repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+      tag: "0.58.0"
     scrape_configs_file: scrape_configs.yaml
     resources:
       limits:

--- a/charts/collector-k8s/values-daemonset.yaml
+++ b/charts/collector-k8s/values-daemonset.yaml
@@ -2,7 +2,7 @@ collectors:
   # The deployment collector should be configured to scrape infrastructure or static targets.
   - name: deployment
     enabled: false
-    image: otel/opentelemetry-collector-contrib:0.58.0
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.58.0
     scrape_configs_file: scrape_configs.yaml
     resources:
       limits:
@@ -48,7 +48,7 @@ collectors:
 
   # The daemonset collector should be configured to scrape general app metrics that contains `prometheus.io/scrape: true` annotation.
   - name: daemonset
-    image: otel/opentelemetry-collector-contrib:0.52.0
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.52.0
     enabled: true
     mode: daemonset
     scrape_configs_file: scrape_configs_ds.yaml

--- a/charts/collector-k8s/values-statefulset.yaml
+++ b/charts/collector-k8s/values-statefulset.yaml
@@ -1,12 +1,16 @@
 collectors:
   - name: statefulset
-    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.58.0
+    image:
+      repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+      tag: "0.58.0"
     enabled: true
     mode: statefulset
     replicas: 3
     targetallocator:
       enabled: true
-      image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.1.0
+      image: 
+        repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+        tag: "0.1.0"
       prometheusCR:
         enabled: false
     scrape_configs_file: scrape_configs_statefulset.yaml

--- a/charts/collector-k8s/values-statefulset.yaml
+++ b/charts/collector-k8s/values-statefulset.yaml
@@ -1,6 +1,6 @@
 collectors:
   - name: statefulset
-    image: otel/opentelemetry-collector-contrib:0.58.0
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.58.0
     enabled: true
     mode: statefulset
     replicas: 3

--- a/charts/collector-k8s/values.yaml
+++ b/charts/collector-k8s/values.yaml
@@ -1,6 +1,8 @@
 collectors:
   - name: deployment
-    image: otel/opentelemetry-collector-contrib:0.61.0
+    image:
+      repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+      tag: "0.61.0"
     replicas: 1
     enabled: true
     scrape_configs_file: scrape_configs.yaml

--- a/charts/kube-otel-stack/templates/collector.yaml
+++ b/charts/kube-otel-stack/templates/collector.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- include "kube-otel-stack.labels" $ | indent 4 }}
 spec:
   mode: {{ $collector.mode }}
-  image: {{ $collector.image }}
+  image: "{{ $collector.image.repository }}:{{ $collector.image.tag | default $.Chart.AppVersion }}"
   replicas: {{ $collector.replicas | default 1 }}
   {{- with $collector.hpa }}
   {{- if .enabled }}
@@ -44,7 +44,7 @@ spec:
 {{- if $collector.targetallocator.enabled }}
   targetAllocator:
     enabled: true
-    image: {{ $collector.targetallocator.image }}
+    image: "{{ $collector.targetallocator.image.repository }}:{{ $collector.targetallocator.image.tag | default $.Chart.AppVersion }}"
     replicas: {{ $collector.targetallocator.replicas }}
     allocationStrategy: {{ $collector.targetallocator.allocationStrategy }}
     {{- if $collector.targetallocator.resources }}

--- a/charts/kube-otel-stack/values.yaml
+++ b/charts/kube-otel-stack/values.yaml
@@ -59,7 +59,9 @@ tracesCollector:
   name: traces
   clusterName: ""
 
-  image: otel/opentelemetry-collector-contrib:0.96.0
+  image: 
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+    tag: "0.96.0"
   mode: deployment
   replicas: 1
   hpa:
@@ -220,7 +222,9 @@ tracesCollector:
 metricsCollector:
   name: metrics
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.96.0
+  image: 
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+    tag: "0.96.0"
   enabled: true
   mode: statefulset
   replicas: 3
@@ -233,7 +237,9 @@ metricsCollector:
     enabled: true
     allocationStrategy: "consistent-hashing"
     replicas: 2
-    image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.96.0
+    image: 
+      repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+      tag: "0.96.0"
     prometheusCR:
       enabled: true
     # Override Default targetAllocator resources
@@ -348,7 +354,9 @@ metricsCollector:
 logsCollector:
   name: logs
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.96.0
+  image: 
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+    tag: "0.96.0"
   enabled: false
   mode: daemonset
   resources:

--- a/charts/otel-cloud-stack/templates/collector.yaml
+++ b/charts/otel-cloud-stack/templates/collector.yaml
@@ -28,7 +28,7 @@ spec:
     {{- $collector.tolerations | toYaml | nindent 4 }}
   {{- end }}
   mode: {{ $collector.mode }}
-  image: {{ $collector.image }}
+  image: "{{ $collector.image.repository }}:{{ $collector.image.tag | default $.Chart.AppVersion }}"
   {{- if not (eq $collector.mode "daemonset") }}
   replicas: {{ $collector.replicas | default 1 }}
   {{- end }}
@@ -51,7 +51,7 @@ spec:
 {{- if $collector.targetallocator.enabled }}
   targetAllocator:
     enabled: true
-    image: {{ $collector.targetallocator.image }}
+    image: "{{ $collector.targetallocator.image.repository }}:{{ $collector.targetallocator.image.tag | default $.Chart.AppVersion }}"
     replicas: {{ $collector.targetallocator.replicas }}
     allocationStrategy: {{ $collector.targetallocator.allocationStrategy }}
     {{- if $collector.targetallocator.resources }}

--- a/charts/otel-cloud-stack/values.yaml
+++ b/charts/otel-cloud-stack/values.yaml
@@ -41,7 +41,9 @@ autoinstrumentation:
 daemonCollector:
   name: daemon
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.96.0
+  image:
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+    tag: "0.96.0"
   enabled: true
   mode: daemonset
   mountHostFS: true
@@ -305,7 +307,9 @@ daemonCollector:
 clusterCollector:
   name: cluster-stats
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.96.0
+  image: 
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+    tag: "0.96.0"
   replicas: 1
   mode: deployment
   enabled: true
@@ -426,7 +430,9 @@ tracesCollector:
   enabled: false
   name: traces
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.96.0
+  image: 
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+    tag: "0.96.0"
   mode: deployment
   hpa:
     minReplicas: 1
@@ -542,7 +548,9 @@ logsCollector:
   enabled: false
   name: logs
   clusterName: ""
-  image: otel/opentelemetry-collector-contrib:0.96.0
+  image: 
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+    tag: "0.96.0"
   mode: daemonset
   resources:
     limits:


### PR DESCRIPTION

Description
---------------------

Updated to image repository to download using ghcr.io instead of docker.io

How Has This Been Tested?
---------------------

helm install otel-cloud-stack ./otel-cloud-stack -n servicenow-cloud-observability --create-namespace --set tracesCollector.enabled=true --set logsCollector.enabled=true --set clusterName=minikube 


***
R/CC: _Who should know about this change? Requesting any reviewers in particular?_
