### PR TITLE
Map attribute service_version to service.version in recommended VM config

### DIFF
--- a/example/vm/config.yaml
+++ b/example/vm/config.yaml
@@ -129,6 +129,15 @@ processors:
         send_batch_size: 1000
         timeout: 1s
         send_batch_max_size: 1500
+    attributes:
+        # The attributes processor modifies attributes of a span, log, or metric. In this case, the
+        # attributes processor maps the `service_version` attribute attached to telemetry from the
+        # prometheus/self receiver to `service.version` following OTel semantic conventions for
+        # service attributes.
+        actions:
+            - key: service.version
+              action: insert
+              from_value: service_version
     resourcedetection/env:
         # This is used to gather resource information from the host and is used in the resource value of telemetry data.
         # For more details, see

--- a/example/vm/config.yaml
+++ b/example/vm/config.yaml
@@ -130,11 +130,15 @@ processors:
         timeout: 1s
         send_batch_max_size: 1500
     attributes:
-        # The attributes processor modifies attributes of a span, log, or metric. In this case, the
-        # attributes processor maps the `service_version` attribute attached to telemetry from the
-        # prometheus/self receiver to `service.version` following OTel semantic conventions for
-        # service attributes.
+        # The attributes processor modifies attributes of a span, log, or metric.
+        # For more details, see:
+        # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor
         actions:
+            # In this case, the attributes processor maps the `service_version` attribute attached
+            # to telemetry from the prometheus/self receiver to `service.version` following OTel
+            # semantic conventions for service attributes.
+            # For more details, see:
+            # https://opentelemetry.io/docs/specs/semconv/attributes-registry/service/
             - key: service.version
               action: insert
               from_value: service_version


### PR DESCRIPTION
Problem
---------------------
The `prometheus/self` receiver is valuable for having the collector send metrics about itself, but by using prometheus it does not follow semantic conventions that CloudObs relies on

Solution
---------------------
In the VM example collector configuration, add an [attribute processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor) configured to insert `service.version` with the `service_version` attribute value

How Has This Been Tested?
---------------------

Running the collector with this change added the `service.version` attribute
