### PR TITLE
Configure attribute processing

### DIFF
--- a/example/vm/config.yaml
+++ b/example/vm/config.yaml
@@ -142,7 +142,7 @@ processors:
             - key: service.version
               action: insert
               from_value: service_version
-            - key: service.version
+            - key: service.name
               action: upsert
               from_value: collector_name
     resourcedetection/env:

--- a/example/vm/config.yaml
+++ b/example/vm/config.yaml
@@ -144,7 +144,7 @@ processors:
               from_value: service_version
             - key: service.name
               action: upsert
-              from_value: collector_name
+              from_value: service_name
     resourcedetection/env:
         # This is used to gather resource information from the host and is used in the resource value of telemetry data.
         # For more details, see

--- a/example/vm/config.yaml
+++ b/example/vm/config.yaml
@@ -141,10 +141,10 @@ processors:
             # https://opentelemetry.io/docs/specs/semconv/attributes-registry/service/
             - key: service.version
               action: insert
-              from_value: service_version
+              from_attribute: service_version
             - key: service.name
               action: upsert
-              from_value: service_name
+              from_attribute: service_name
     resourcedetection/env:
         # This is used to gather resource information from the host and is used in the resource value of telemetry data.
         # For more details, see

--- a/example/vm/config.yaml
+++ b/example/vm/config.yaml
@@ -134,14 +134,17 @@ processors:
         # For more details, see:
         # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor
         actions:
-            # In this case, the attributes processor maps the `service_version` attribute attached
-            # to telemetry from the prometheus/self receiver to `service.version` following OTel
-            # semantic conventions for service attributes.
+            # In this case, the attributes processor maps service attributes attached to telemetry
+            # from the prometheus/self receiver to service attributes following OTel semantic
+            # conventions for service attributes.
             # For more details, see:
             # https://opentelemetry.io/docs/specs/semconv/attributes-registry/service/
             - key: service.version
               action: insert
               from_value: service_version
+            - key: service.version
+              action: upsert
+              from_value: collector_name
     resourcedetection/env:
         # This is used to gather resource information from the host and is used in the resource value of telemetry data.
         # For more details, see
@@ -242,13 +245,13 @@ service:
     pipelines:
         traces:
             receivers: [otlp]
-            processors: [batch, resourcedetection/env]
+            processors: [resourcedetection/env, attributes, batch]
             exporters: [debug, otlp/ls]
         metrics:
             receivers: [otlp, prometheus/self, hostmetrics]
-            processors: [batch, resourcedetection/env]
+            processors: [resourcedetection/env, attributes, batch]
             exporters: [debug, otlp/ls]
         logs:
             exporters: [debug, otlp/ls]
-            processors: [batch, resourcedetection/env]
+            processors: [resourcedetection/env, attributes, batch]
             receivers: [otlp] # update with your receiver name


### PR DESCRIPTION
Description
---------------------

- Wire up the the attributes processor into the pipelines
- Add attribute processor mapping to apply the `collector_name` label on metrics from the prometheus receiver as `service.name` for a better display name
- Reorder the pipeline processors so that batching happens last (before export)